### PR TITLE
Phase 3: completeness & hardening

### DIFF
--- a/completeness_test.go
+++ b/completeness_test.go
@@ -1,0 +1,70 @@
+package melody
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDelete(t *testing.T) {
+	q, p, err := NewDelete("users").Where("id", "=", 1).Get()
+	eq(t, "delete", q, p, err, "DELETE FROM users WHERE id = ?", []interface{}{1})
+}
+
+func TestDeleteNoTable(t *testing.T) {
+	_, _, err := NewDelete("").Get()
+	if err == nil {
+		t.Fatal("expected error when no table defined")
+	}
+}
+
+func TestDeletePostgresReturning(t *testing.T) {
+	q, p, err := NewDelete("users").Dialect(Postgres).
+		Where("id", "=", 1).Returning("id").Get()
+	eq(t, "delete returning", q, p, err,
+		"DELETE FROM users WHERE id = $1 RETURNING id", []interface{}{1})
+}
+
+func TestInsertReturning(t *testing.T) {
+	q, p, err := NewInsert("users").Dialect(Postgres).
+		Set("name", "bob").Returning("id", "created_at").Get()
+	eq(t, "insert returning", q, p, err,
+		"INSERT INTO users (name) VALUES( $1 ) RETURNING id, created_at",
+		[]interface{}{"bob"})
+}
+
+func TestUpdateReturning(t *testing.T) {
+	q, p, err := NewUpdate("users").
+		Set("name", "bob").Where("id", "=", 1).Returning("updated_at").Get()
+	eq(t, "update returning", q, p, err,
+		"UPDATE users SET name = ? WHERE id = ? RETURNING updated_at",
+		[]interface{}{"bob", 1})
+}
+
+func TestParseStructWithTimeAndNested(t *testing.T) {
+	type Address struct {
+		City string `json:"city" db:"city"`
+	}
+	type User struct {
+		ID        int       `json:"id" db:"id"`
+		CreatedAt time.Time `json:"created_at" db:"created_at"`
+		Address   Address   `json:"address"`
+		secret    string    // unexported, must be ignored
+	}
+
+	b := New("users")
+	b.parseStruct(User{})
+
+	want := map[string]string{
+		"id":           "id",
+		"created_at":   "created_at",   // time.Time mapped, not recursed
+		"address.city": "city",          // nested struct prefixed
+	}
+	for k, v := range want {
+		if got := b.ctx.JsonToDB[k]; got != v {
+			t.Errorf("JsonToDB[%q] = %q, want %q", k, got, v)
+		}
+	}
+	if len(b.ctx.JsonToDB) != len(want) {
+		t.Errorf("unexpected extra mappings: %#v", b.ctx.JsonToDB)
+	}
+}

--- a/delete.go
+++ b/delete.go
@@ -1,0 +1,114 @@
+package melody
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type DeleteBuilder struct {
+	ctx     deleteContext
+	dialect Dialect
+}
+
+type deleteContext struct {
+	Table     string
+	Where     []WhereContext
+	Returning []string
+}
+
+func NewDelete(table string) *DeleteBuilder {
+	return &DeleteBuilder{
+		ctx: deleteContext{
+			Table: table,
+		},
+	}
+}
+
+// Dialect sets the SQL dialect used to render the final query.
+func (d *DeleteBuilder) Dialect(dialect Dialect) *DeleteBuilder {
+	d.dialect = dialect
+	return d
+}
+
+// Returning adds a RETURNING clause (Postgres / SQLite syntax).
+func (d *DeleteBuilder) Returning(columns ...string) *DeleteBuilder {
+	d.ctx.Returning = append(d.ctx.Returning, columns...)
+	return d
+}
+
+func (d *DeleteBuilder) Where(key string, operator string, values ...interface{}) *DeleteBuilder {
+	return d.where(key, operator, values, false, false)
+}
+
+func (d *DeleteBuilder) OrWhere(key string, operator string, values ...interface{}) *DeleteBuilder {
+	return d.where(key, operator, values, true, false)
+}
+
+func (d *DeleteBuilder) GroupWhere(sub SubBuilderFunc) *DeleteBuilder {
+	return d.sub(sub, false)
+}
+
+func (d *DeleteBuilder) OrGroupWhere(sub SubBuilderFunc) *DeleteBuilder {
+	return d.sub(sub, true)
+}
+
+func (d *DeleteBuilder) sub(sub SubBuilderFunc, isOr bool) *DeleteBuilder {
+	wc := &WhereContext{IsOr: isOr}
+	sub(wc)
+	d.ctx.Where = append(d.ctx.Where, *wc)
+	return d
+}
+
+func (d *DeleteBuilder) where(key, operator string, values []interface{}, isOr, isOn bool) *DeleteBuilder {
+	d.ctx.Where = append(d.ctx.Where, WhereContext{
+		Values: []where{
+			{
+				Key:      key,
+				Operator: strings.ToUpper(operator),
+				Values:   values,
+				IsOr:     isOr,
+				IsOn:     isOn,
+			},
+		},
+	})
+	return d
+}
+
+func (d *DeleteBuilder) Get() (query string, params []interface{}, err error) {
+	query, params, err = d.build()
+	if err != nil {
+		return query, params, err
+	}
+	if d.dialect != nil {
+		query = d.dialect.Rebind(query)
+	}
+	return query, params, err
+}
+
+func (d *DeleteBuilder) build() (res string, params []interface{}, err error) {
+	if d.ctx.Table == "" {
+		return res, params, errors.New("one table need to be defined")
+	}
+
+	result := []string{fmt.Sprintf("DELETE FROM %s", d.ctx.Table)}
+
+	for i, wc := range d.ctx.Where {
+		var r []string
+		var p []interface{}
+
+		r, p, err = buildWhere(wc, i == 0, false, false)
+		if err != nil {
+			return
+		}
+
+		result = append(result, r...)
+		params = append(params, p...)
+	}
+
+	if len(d.ctx.Returning) != 0 {
+		result = append(result, "RETURNING "+strings.Join(d.ctx.Returning, ", "))
+	}
+
+	return strings.Join(result, " "), params, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ermos/melody
 
-go 1.17
+go 1.21

--- a/insert.go
+++ b/insert.go
@@ -15,6 +15,7 @@ type insertContext struct {
 	Table            string
 	Value            []insertValue
 	withDuplicateKey bool
+	Returning        []string
 }
 
 type insertValue struct {
@@ -37,8 +38,16 @@ func (i *InsertBuilder) Dialect(d Dialect) *InsertBuilder {
 	return i
 }
 
+// ponytail: single-row insert only. Multi-row VALUES (...),(...) needs an
+// AddRow-style API redesign of InsertBuilder; add when batch inserts are needed.
 func (i *InsertBuilder) Set(column string, value interface{}) *InsertBuilder {
 	i.ctx.Value = append(i.ctx.Value, insertValue{Column: column, Value: value})
+	return i
+}
+
+// Returning adds a RETURNING clause (Postgres / SQLite syntax).
+func (i *InsertBuilder) Returning(columns ...string) *InsertBuilder {
+	i.ctx.Returning = append(i.ctx.Returning, columns...)
 	return i
 }
 
@@ -91,6 +100,10 @@ func (i *InsertBuilder) build() (res string, params []interface{}, err error) {
 
 		result = append(result, "ON DUPLICATE KEY UPDATE")
 		result = append(result, strings.Join(resultOnUpdate, ", "))
+	}
+
+	if len(i.ctx.Returning) != 0 {
+		result = append(result, "RETURNING "+strings.Join(i.ctx.Returning, ", "))
 	}
 
 	return strings.Join(result, " "), params, nil

--- a/query.go
+++ b/query.go
@@ -6,7 +6,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
+
+var timeType = reflect.TypeOf(time.Time{})
 
 func (b *Builder) WithQueryParams(model interface{}, qp map[string]string) (*Builder, error) {
 	var page, perPage int
@@ -103,17 +106,43 @@ func parseStruct(st interface{}, data map[string]string, sub string) {
 	t := reflect.TypeOf(st)
 	val := reflect.ValueOf(st)
 
+	for t != nil && t.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return
+		}
+		t = t.Elem()
+		val = val.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return
+	}
+
 	for i := 0; i < t.NumField(); i++ {
 		s := t.Field(i)
+		if s.PkgPath != "" { // unexported field
+			continue
+		}
+
 		json := strings.ReplaceAll(s.Tag.Get("json"), ",omitempty", "")
 		sql := s.Tag.Get("db")
 
-		if s.Type.Kind().String() == "struct" {
-			parseStruct(val.Field(i).Interface(), data, sub+json+".")
-		}
-
+		// A field carrying a db tag is a column, even when its Go type is a
+		// struct (e.g. time.Time): map it and do not recurse into it.
 		if json != "-" && json != "" && sql != "" {
 			data[sub+json] = sql
+			continue
+		}
+
+		ft := s.Type
+		for ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		if ft.Kind() == reflect.Struct && ft != timeType {
+			prefix := sub
+			if json != "" && json != "-" {
+				prefix = sub + json + "."
+			}
+			parseStruct(val.Field(i).Interface(), data, prefix)
 		}
 	}
 }

--- a/update.go
+++ b/update.go
@@ -12,9 +12,10 @@ type UpdateBuilder struct {
 }
 
 type updateContext struct {
-	Table string
-	Value []updateValue
-	Where []WhereContext
+	Table     string
+	Value     []updateValue
+	Where     []WhereContext
+	Returning []string
 }
 
 type updateValue struct {
@@ -38,6 +39,12 @@ func (u *UpdateBuilder) Dialect(d Dialect) *UpdateBuilder {
 
 func (u *UpdateBuilder) Set(column string, value interface{}) *UpdateBuilder {
 	u.ctx.Value = append(u.ctx.Value, updateValue{Column: column, Value: value})
+	return u
+}
+
+// Returning adds a RETURNING clause (Postgres / SQLite syntax).
+func (u *UpdateBuilder) Returning(columns ...string) *UpdateBuilder {
+	u.ctx.Returning = append(u.ctx.Returning, columns...)
 	return u
 }
 
@@ -77,6 +84,10 @@ func (u *UpdateBuilder) build() (res string, params []interface{}, err error) {
 
 		result = append(result, r...)
 		params = append(params, p...)
+	}
+
+	if len(u.ctx.Returning) != 0 {
+		result = append(result, "RETURNING "+strings.Join(u.ctx.Returning, ", "))
 	}
 
 	return strings.Join(result, " "), params, nil


### PR DESCRIPTION
## Phase 3 — Complétude & durcissement

> Stack sur `phase-2-dialect`. À merger après la Phase 2.

### Ajouts
- **`DeleteBuilder`** (`NewDelete`) — complète le CRUD, réutilise `buildWhere`.
- **`RETURNING`** sur Insert/Update/Delete (`.Returning(cols...)`, syntaxe pg/sqlite).
- **`parseStruct` corrigé** :
  - `reflect.Struct` au lieu de comparaison de string ;
  - `time.Time` traité comme colonne, plus de récursion dedans ;
  - préfixe `.field` quand `json==""` corrigé ;
  - déréférencement des pointeurs + champs non-exportés ignorés.
- `go.mod` → 1.21.

### Différé (volontaire, noté en `ponytail:`)
- **INSERT multi-lignes** : nécessite un redesign `AddRow` de `InsertBuilder`.
- **Auto-quoting des identifiants** : l'API directe (`Where`/`On`/`OrderBy`) prend des identifiants fournis par le dev (même niveau de confiance qu'écrire le SQL) ; quoter casserait `table.col` et les expressions. La vraie frontière de confiance (`WithQueryParams`) est déjà couverte (colonnes mappées + opérateurs fixes + erreur si inconnu, cf. Phase 1).
- **`interface{}`→`any`** : churn cosmétique qui noierait la review ; à faire en passe dédiée si souhaité.

Tests : Delete (+ no-table, returning), Insert/Update returning, parseStruct (time.Time + nested + unexported). 29 tests verts, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)