### PR TITLE
Phase 4: coherence (README + Meta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,136 @@
 # melody
-🎶 Build your queries like a melody
+
+🎶 Build your SQL queries like a melody — a small, dialect-agnostic query builder for Go.
+
+```bash
+go get github.com/ermos/melody
+```
+
+## Quick start
+
+```go
+import "github.com/ermos/melody"
+
+q, params, err := melody.New("users").
+    Dialect(melody.Postgres).
+    Select("id", "name").
+    Where("active", "=", true).
+    Where("age", ">", 18).
+    OrderBy("name", melody.Asc).
+    Limit(20).
+    Get()
+// q      => SELECT id, name FROM users WHERE active = $1 AND age > $2 ORDER BY name ASC LIMIT 20
+// params => [true, 18]
+```
+
+Every value is bound as a parameter — melody never interpolates values into the SQL string.
+
+## Dialects
+
+The builder emits `?` placeholders internally; the dialect rewrites them on render.
+
+| Dialect            | Placeholders | Notes                              |
+|--------------------|--------------|------------------------------------|
+| `melody.Default`   | `?`          | MySQL / SQLite. Used when unset.   |
+| `melody.Postgres`  | `$1, $2, …`  | Set via `.Dialect(melody.Postgres)`|
+
+Implement `melody.Dialect` to add your own.
+
+## SELECT
+
+```go
+melody.New("users").
+    Distinct().
+    Select("country", "count(*)").
+    Where("active", "=", true).
+    GroupBy("country").
+    OrderBy("country", melody.Asc).
+    Limit(10).Offset(20).
+    Get()
+```
+
+### WHERE / OR / IN / groups
+
+```go
+melody.New("users").
+    Where("status", "IN", "active", "pending").
+    OrGroupWhere(func(w *melody.WhereContext) {
+        w.Where("age", ">", 65).Where("vip", "=", true)
+    }).
+    Get()
+// ... WHERE status IN (?,?) OR ( age > ? AND vip = ? )
+```
+
+### JOIN
+
+```go
+melody.New("users").
+    LeftJoin("orders", func(w *melody.WhereContext) {
+        w.On("orders.user_id", "=", "users.id")
+    }).
+    Get()
+```
+
+### COUNT
+
+```go
+melody.New("users").Where("active", "=", true).GetCount()        // SELECT count(*) ...
+melody.New("users").GetCountWithKey("id")                        // SELECT count(id) ...
+```
+
+## INSERT / UPDATE / DELETE
+
+```go
+melody.NewInsert("users").Dialect(melody.Postgres).
+    Set("name", "bob").Set("age", 30).
+    Returning("id").
+    Get()
+// INSERT INTO users (name, age) VALUES( $1, $2 ) RETURNING id
+
+melody.NewUpdate("users").
+    Set("name", "bob").
+    Where("id", "=", 1).
+    Get()
+// UPDATE users SET name = ? WHERE id = ?
+
+melody.NewDelete("users").
+    Where("id", "=", 1).
+    Get()
+// DELETE FROM users WHERE id = ?
+```
+
+## HTTP query params → WHERE
+
+Map JSON field names (from your model's `json`/`db` tags) to columns and build a
+filtered query straight from request query parameters:
+
+```go
+type User struct {
+    ID   int    `json:"id" db:"id"`
+    Name string `json:"name" db:"name"`
+}
+
+b, err := melody.New("users").WithQueryParams(User{}, map[string]string{
+    "name%5Blike%5D": "bob",  // name[like]=bob
+    "per_page":       "20",
+    "page":           "2",
+})
+// ... WHERE name LIKE ? ... LIMIT 20 OFFSET 20
+```
+
+Supported conditions: `equal`, `not-equal`, `like`, `not-like`, `in`, `not-in`.
+Unknown params or conditions return an error instead of producing broken SQL.
+
+## Pagination response
+
+```go
+result := melody.NewResult(users, total, perPage, page)
+// result.Meta.Pages computed as ceil(total/perPage)
+```
+
+## Status
+
+- `database/sql`-style output: `(query string, params []interface{}, err error)` — bring your own driver.
+- Identifiers passed to `Where`/`On`/`OrderBy`/`Select` are emitted as-is; treat them
+  as developer-controlled (same trust level as hand-written SQL). User input belongs in
+  values (bound params) or in `WithQueryParams` (mapped columns).

--- a/meta.go
+++ b/meta.go
@@ -17,3 +17,20 @@ type Result struct {
 	Meta Meta        `json:"meta"`
 	Body interface{} `json:"body"`
 }
+
+// NewResult wraps a body with pagination metadata. perPage and page mirror the
+// values consumed by Builder.WithQueryParams; Pages is the total page count.
+func NewResult(body interface{}, total, perPage, page int) Result {
+	pages := 0
+	if perPage > 0 {
+		pages = (total + perPage - 1) / perPage // ceil(total/perPage)
+	}
+	return Result{
+		Meta: Meta{
+			Total:     total,
+			NbPerPage: perPage,
+			Pages:     pages,
+		},
+		Body: body,
+	}
+}

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,0 +1,22 @@
+package melody
+
+import "testing"
+
+func TestNewResultPages(t *testing.T) {
+	cases := []struct {
+		total, perPage, wantPages int
+	}{
+		{0, 10, 0},
+		{10, 10, 1},
+		{11, 10, 2},
+		{25, 10, 3},
+		{5, 0, 0}, // perPage 0 -> no division
+	}
+	for _, c := range cases {
+		r := NewResult(nil, c.total, c.perPage, 1)
+		if r.Meta.Pages != c.wantPages {
+			t.Errorf("NewResult(total=%d,perPage=%d).Pages = %d, want %d",
+				c.total, c.perPage, r.Meta.Pages, c.wantPages)
+		}
+	}
+}


### PR DESCRIPTION
## Phase 4 — Cohérence finale

> Stack sur `phase-3-completeness`. À merger en dernier.

### `meta.go` — décision : garder + câbler (pas supprimer)
`Meta`/`Result` étaient orphelins (aucune référence dans la lib) **mais exportés et publiés** (tags v1.x) → suppression = breaking. Je leur donne un rôle :
- **`NewResult(body, total, perPage, page)`** calcule `Meta.Pages = ceil(total/perPage)` et relie ces types à la pagination que `WithQueryParams` produit déjà.

### README
Réécriture complète : quick start Postgres, table des dialectes, CRUD complet (SELECT/INSERT/UPDATE/DELETE), WHERE/OR/IN/groups/JOIN/COUNT, `WithQueryParams`, pagination, et note sur la frontière de confiance des identifiants.

30 tests verts.

---

### ⚠️ Note versioning (pour l'ensemble du chantier)
La Phase 1 change la signature de `WithQueryParams` → `(*Builder, error)` : **breaking**. Les tags actuels sont en `v1.x`, donc une fois les 5 phases mergées, ça justifie un **`v2.0.0`** (et le `/v2` dans le module path si tu suis les règles Go modules). À toi de trancher au tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)