### PR TITLE
Phase 5: interface{} -> any

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -36,7 +36,7 @@ type WhereContext struct {
 type where struct {
 	Key      string
 	Operator string
-	Values   []interface{}
+	Values   []any
 	IsOn     bool
 	IsOr     bool
 }
@@ -104,17 +104,17 @@ func (b *Builder) Offset(offset int) *Builder {
 	return b
 }
 
-func (b *Builder) Get() (query string, params []interface{}, err error) {
+func (b *Builder) Get() (query string, params []any, err error) {
 	query, params, err = b.build(true)
 	return b.rebind(b.withFields(b.withLimitOffset(query))), params, err
 }
 
-func (b *Builder) GetCount() (query string, params []interface{}, err error) {
+func (b *Builder) GetCount() (query string, params []any, err error) {
 	query, params, err = b.build(false)
 	return b.rebind(b.withCount(query, "")), params, err
 }
 
-func (b *Builder) GetCountWithKey(key string) (query string, params []interface{}, err error) {
+func (b *Builder) GetCountWithKey(key string) (query string, params []any, err error) {
 	query, params, err = b.build(false)
 	return b.rebind(b.withCount(query, key)), params, err
 }
@@ -127,7 +127,7 @@ func (b *Builder) GetLimit() int {
 	return b.ctx.Limit
 }
 
-func buildWhere(wc WhereContext, isFirst, isJoin, isSub bool) (result []string, params []interface{}, err error) {
+func buildWhere(wc WhereContext, isFirst, isJoin, isSub bool) (result []string, params []any, err error) {
 	valuesLen := len(wc.Values)
 
 	if isFirst && !isJoin && valuesLen != 0 {
@@ -177,7 +177,7 @@ func buildWhere(wc WhereContext, isFirst, isJoin, isSub bool) (result []string, 
 
 	for i, s := range wc.Sub {
 		var r []string
-		var p []interface{}
+		var p []any
 
 		r, p, err = buildWhere(s, isFirst && i == 0 && len(wc.Values) == 0, isJoin, true)
 		if err != nil {
@@ -230,7 +230,7 @@ func (b *Builder) withLimitOffset(query string) string {
 	return query
 }
 
-func (b *Builder) build(withOrderBy bool) (res string, params []interface{}, err error) {
+func (b *Builder) build(withOrderBy bool) (res string, params []any, err error) {
 	var result []string
 
 	if len(b.ctx.Table) == 0 {
@@ -251,7 +251,7 @@ func (b *Builder) build(withOrderBy bool) (res string, params []interface{}, err
 
 	for _, j := range b.ctx.Join {
 		var r []string
-		var p []interface{}
+		var p []any
 
 		result = append(result, fmt.Sprintf("%s %s ON", j.Type, j.Table))
 
@@ -266,7 +266,7 @@ func (b *Builder) build(withOrderBy bool) (res string, params []interface{}, err
 
 	for i, wc := range b.ctx.Where {
 		var r []string
-		var p []interface{}
+		var p []any
 
 		r, p, err = buildWhere(wc, i == 0, false, false)
 		if err != nil {

--- a/builder_test.go
+++ b/builder_test.go
@@ -9,7 +9,7 @@ import (
 // (including known quirks) so later refactors are provably behaviour-preserving.
 // Where a case documents a known bug, the comment says so.
 
-func eq(t *testing.T, name, gotQuery string, gotParams []interface{}, gotErr error, wantQuery string, wantParams []interface{}) {
+func eq(t *testing.T, name, gotQuery string, gotParams []any, gotErr error, wantQuery string, wantParams []any) {
 	t.Helper()
 	if gotErr != nil {
 		t.Fatalf("%s: unexpected error: %v", name, gotErr)
@@ -42,22 +42,22 @@ func TestSelectDistinct(t *testing.T) {
 
 func TestWhereSingle(t *testing.T) {
 	q, p, err := New("users").Where("id", "=", 1).Get()
-	eq(t, "where single", q, p, err, "SELECT * FROM users WHERE id = ?", []interface{}{1})
+	eq(t, "where single", q, p, err, "SELECT * FROM users WHERE id = ?", []any{1})
 }
 
 func TestWhereAnd(t *testing.T) {
 	q, p, err := New("users").Where("id", "=", 1).Where("name", "=", "bob").Get()
-	eq(t, "where and", q, p, err, "SELECT * FROM users WHERE id = ? AND name = ?", []interface{}{1, "bob"})
+	eq(t, "where and", q, p, err, "SELECT * FROM users WHERE id = ? AND name = ?", []any{1, "bob"})
 }
 
 func TestWhereOr(t *testing.T) {
 	q, p, err := New("users").Where("id", "=", 1).OrWhere("id", "=", 2).Get()
-	eq(t, "where or", q, p, err, "SELECT * FROM users WHERE id = ? OR id = ?", []interface{}{1, 2})
+	eq(t, "where or", q, p, err, "SELECT * FROM users WHERE id = ? OR id = ?", []any{1, 2})
 }
 
 func TestWhereIn(t *testing.T) {
 	q, p, err := New("users").Where("id", "IN", 1, 2, 3).Get()
-	eq(t, "where in", q, p, err, "SELECT * FROM users WHERE id IN (?,?,?)", []interface{}{1, 2, 3})
+	eq(t, "where in", q, p, err, "SELECT * FROM users WHERE id IN (?,?,?)", []any{1, 2, 3})
 }
 
 func TestGroupWhere(t *testing.T) {
@@ -68,7 +68,7 @@ func TestGroupWhere(t *testing.T) {
 		}).Get()
 	eq(t, "group where", q, p, err,
 		"SELECT * FROM users WHERE active = ? AND ( age > ? OR vip = ? )",
-		[]interface{}{true, 18, true})
+		[]any{true, 18, true})
 }
 
 func TestOrderByGroupByLimitOffset(t *testing.T) {
@@ -81,7 +81,7 @@ func TestOrderByGroupByLimitOffset(t *testing.T) {
 		Get()
 	eq(t, "full", q, p, err,
 		"SELECT * FROM users WHERE active = ? GROUP BY country ORDER BY name ASC LIMIT 10 OFFSET 20",
-		[]interface{}{true})
+		[]any{true})
 }
 
 func TestJoin(t *testing.T) {
@@ -95,7 +95,7 @@ func TestJoin(t *testing.T) {
 
 func TestCount(t *testing.T) {
 	q, p, err := New("users").Where("active", "=", true).GetCount()
-	eq(t, "count", q, p, err, "SELECT count(*) FROM users WHERE active = ?", []interface{}{true})
+	eq(t, "count", q, p, err, "SELECT count(*) FROM users WHERE active = ?", []any{true})
 }
 
 func TestCountWithKey(t *testing.T) {
@@ -113,7 +113,7 @@ func TestNoTableErrors(t *testing.T) {
 func TestInsert(t *testing.T) {
 	q, p, err := NewInsert("users").Set("name", "bob").Set("age", 30).Get()
 	eq(t, "insert", q, p, err,
-		"INSERT INTO users (name, age) VALUES( ?, ? )", []interface{}{"bob", 30})
+		"INSERT INTO users (name, age) VALUES( ?, ? )", []any{"bob", 30})
 }
 
 func TestOrGroupWhere(t *testing.T) {
@@ -125,7 +125,7 @@ func TestOrGroupWhere(t *testing.T) {
 		}).Get()
 	eq(t, "or group", q, p, err,
 		"SELECT * FROM users WHERE a = ? OR ( b = ? AND c = ? )",
-		[]interface{}{1, 2, 3})
+		[]any{1, 2, 3})
 }
 
 func TestCountIgnoresOrderBy(t *testing.T) {
@@ -155,5 +155,5 @@ func TestPlaceholders(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	q, p, err := NewUpdate("users").Set("name", "bob").Where("id", "=", 1).Get()
 	eq(t, "update", q, p, err,
-		"UPDATE users SET name = ? WHERE id = ?", []interface{}{"bob", 1})
+		"UPDATE users SET name = ? WHERE id = ?", []any{"bob", 1})
 }

--- a/completeness_test.go
+++ b/completeness_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestDelete(t *testing.T) {
 	q, p, err := NewDelete("users").Where("id", "=", 1).Get()
-	eq(t, "delete", q, p, err, "DELETE FROM users WHERE id = ?", []interface{}{1})
+	eq(t, "delete", q, p, err, "DELETE FROM users WHERE id = ?", []any{1})
 }
 
 func TestDeleteNoTable(t *testing.T) {
@@ -21,7 +21,7 @@ func TestDeletePostgresReturning(t *testing.T) {
 	q, p, err := NewDelete("users").Dialect(Postgres).
 		Where("id", "=", 1).Returning("id").Get()
 	eq(t, "delete returning", q, p, err,
-		"DELETE FROM users WHERE id = $1 RETURNING id", []interface{}{1})
+		"DELETE FROM users WHERE id = $1 RETURNING id", []any{1})
 }
 
 func TestInsertReturning(t *testing.T) {
@@ -29,7 +29,7 @@ func TestInsertReturning(t *testing.T) {
 		Set("name", "bob").Returning("id", "created_at").Get()
 	eq(t, "insert returning", q, p, err,
 		"INSERT INTO users (name) VALUES( $1 ) RETURNING id, created_at",
-		[]interface{}{"bob"})
+		[]any{"bob"})
 }
 
 func TestUpdateReturning(t *testing.T) {
@@ -37,7 +37,7 @@ func TestUpdateReturning(t *testing.T) {
 		Set("name", "bob").Where("id", "=", 1).Returning("updated_at").Get()
 	eq(t, "update returning", q, p, err,
 		"UPDATE users SET name = ? WHERE id = ? RETURNING updated_at",
-		[]interface{}{"bob", 1})
+		[]any{"bob", 1})
 }
 
 func TestParseStructWithTimeAndNested(t *testing.T) {
@@ -56,8 +56,8 @@ func TestParseStructWithTimeAndNested(t *testing.T) {
 
 	want := map[string]string{
 		"id":           "id",
-		"created_at":   "created_at",   // time.Time mapped, not recursed
-		"address.city": "city",          // nested struct prefixed
+		"created_at":   "created_at", // time.Time mapped, not recursed
+		"address.city": "city",       // nested struct prefixed
 	}
 	for k, v := range want {
 		if got := b.ctx.JsonToDB[k]; got != v {

--- a/delete.go
+++ b/delete.go
@@ -37,11 +37,11 @@ func (d *DeleteBuilder) Returning(columns ...string) *DeleteBuilder {
 	return d
 }
 
-func (d *DeleteBuilder) Where(key string, operator string, values ...interface{}) *DeleteBuilder {
+func (d *DeleteBuilder) Where(key string, operator string, values ...any) *DeleteBuilder {
 	return d.where(key, operator, values, false, false)
 }
 
-func (d *DeleteBuilder) OrWhere(key string, operator string, values ...interface{}) *DeleteBuilder {
+func (d *DeleteBuilder) OrWhere(key string, operator string, values ...any) *DeleteBuilder {
 	return d.where(key, operator, values, true, false)
 }
 
@@ -60,7 +60,7 @@ func (d *DeleteBuilder) sub(sub SubBuilderFunc, isOr bool) *DeleteBuilder {
 	return d
 }
 
-func (d *DeleteBuilder) where(key, operator string, values []interface{}, isOr, isOn bool) *DeleteBuilder {
+func (d *DeleteBuilder) where(key, operator string, values []any, isOr, isOn bool) *DeleteBuilder {
 	d.ctx.Where = append(d.ctx.Where, WhereContext{
 		Values: []where{
 			{
@@ -75,7 +75,7 @@ func (d *DeleteBuilder) where(key, operator string, values []interface{}, isOr, 
 	return d
 }
 
-func (d *DeleteBuilder) Get() (query string, params []interface{}, err error) {
+func (d *DeleteBuilder) Get() (query string, params []any, err error) {
 	query, params, err = d.build()
 	if err != nil {
 		return query, params, err
@@ -86,7 +86,7 @@ func (d *DeleteBuilder) Get() (query string, params []interface{}, err error) {
 	return query, params, err
 }
 
-func (d *DeleteBuilder) build() (res string, params []interface{}, err error) {
+func (d *DeleteBuilder) build() (res string, params []any, err error) {
 	if d.ctx.Table == "" {
 		return res, params, errors.New("one table need to be defined")
 	}
@@ -95,7 +95,7 @@ func (d *DeleteBuilder) build() (res string, params []interface{}, err error) {
 
 	for i, wc := range d.ctx.Where {
 		var r []string
-		var p []interface{}
+		var p []any
 
 		r, p, err = buildWhere(wc, i == 0, false, false)
 		if err != nil {

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -11,21 +11,21 @@ func TestPostgresSelectPlaceholders(t *testing.T) {
 		Get()
 	eq(t, "pg select", q, p, err,
 		"SELECT * FROM users WHERE id = $1 AND name = $2 AND status IN ($3,$4)",
-		[]interface{}{1, "bob", "a", "b"})
+		[]any{1, "bob", "a", "b"})
 }
 
 func TestPostgresInsert(t *testing.T) {
 	q, p, err := NewInsert("users").Dialect(Postgres).
 		Set("name", "bob").Set("age", 30).Get()
 	eq(t, "pg insert", q, p, err,
-		"INSERT INTO users (name, age) VALUES( $1, $2 )", []interface{}{"bob", 30})
+		"INSERT INTO users (name, age) VALUES( $1, $2 )", []any{"bob", 30})
 }
 
 func TestPostgresUpdate(t *testing.T) {
 	q, p, err := NewUpdate("users").Dialect(Postgres).
 		Set("name", "bob").Where("id", "=", 1).Get()
 	eq(t, "pg update", q, p, err,
-		"UPDATE users SET name = $1 WHERE id = $2", []interface{}{"bob", 1})
+		"UPDATE users SET name = $1 WHERE id = $2", []any{"bob", 1})
 }
 
 func TestDefaultDialectUnchanged(t *testing.T) {

--- a/group_where.go
+++ b/group_where.go
@@ -18,20 +18,20 @@ func (b *WhereContext) OrGroupOn(sub SubBuilderFunc) *WhereContext {
 	return b.sub(sub, true)
 }
 
-func (b *WhereContext) Where(key string, operator string, values ...interface{}) *WhereContext {
+func (b *WhereContext) Where(key string, operator string, values ...any) *WhereContext {
 	return b.where(key, operator, values, false, false)
 }
 
-func (b *WhereContext) OrWhere(key string, operator string, values ...interface{}) *WhereContext {
+func (b *WhereContext) OrWhere(key string, operator string, values ...any) *WhereContext {
 	return b.where(key, operator, values, true, false)
 }
 
 func (b *WhereContext) On(firstKey string, operator string, secondKey string) *WhereContext {
-	return b.where(firstKey, operator, []interface{}{secondKey}, false, true)
+	return b.where(firstKey, operator, []any{secondKey}, false, true)
 }
 
 func (b *WhereContext) OrOn(firstKey string, operator string, secondKey string) *WhereContext {
-	return b.where(firstKey, operator, []interface{}{secondKey}, true, true)
+	return b.where(firstKey, operator, []any{secondKey}, true, true)
 }
 
 func (b *WhereContext) sub(sub SubBuilderFunc, isOr bool) *WhereContext {
@@ -46,7 +46,7 @@ func (b *WhereContext) sub(sub SubBuilderFunc, isOr bool) *WhereContext {
 	return b
 }
 
-func (b *WhereContext) where(key, operator string, values []interface{}, isOr, isOn bool) *WhereContext {
+func (b *WhereContext) where(key, operator string, values []any, isOr, isOn bool) *WhereContext {
 	b.Values = append(b.Values, where{
 		Key:      key,
 		Operator: strings.ToUpper(operator),

--- a/insert.go
+++ b/insert.go
@@ -20,7 +20,7 @@ type insertContext struct {
 
 type insertValue struct {
 	Column           string
-	Value            interface{}
+	Value            any
 	withDuplicateKey bool
 }
 
@@ -40,7 +40,7 @@ func (i *InsertBuilder) Dialect(d Dialect) *InsertBuilder {
 
 // ponytail: single-row insert only. Multi-row VALUES (...),(...) needs an
 // AddRow-style API redesign of InsertBuilder; add when batch inserts are needed.
-func (i *InsertBuilder) Set(column string, value interface{}) *InsertBuilder {
+func (i *InsertBuilder) Set(column string, value any) *InsertBuilder {
 	i.ctx.Value = append(i.ctx.Value, insertValue{Column: column, Value: value})
 	return i
 }
@@ -57,7 +57,7 @@ func (i *InsertBuilder) UpdateDuplicateKey() *InsertBuilder {
 	return i
 }
 
-func (i *InsertBuilder) Get() (query string, params []interface{}, err error) {
+func (i *InsertBuilder) Get() (query string, params []any, err error) {
 	query, params, err = i.build()
 	if i.dialect != nil {
 		query = i.dialect.Rebind(query)
@@ -65,7 +65,7 @@ func (i *InsertBuilder) Get() (query string, params []interface{}, err error) {
 	return query, params, err
 }
 
-func (i *InsertBuilder) build() (res string, params []interface{}, err error) {
+func (i *InsertBuilder) build() (res string, params []any, err error) {
 	var result []string
 
 	if i.ctx.Table == "" {

--- a/meta.go
+++ b/meta.go
@@ -8,19 +8,19 @@ type Meta struct {
 }
 
 type MetaField struct {
-	Name  string      `json:"name"`
-	Type  string      `json:"type"`
-	Value interface{} `json:"value,omitempty"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Value any    `json:"value,omitempty"`
 }
 
 type Result struct {
-	Meta Meta        `json:"meta"`
-	Body interface{} `json:"body"`
+	Meta Meta `json:"meta"`
+	Body any  `json:"body"`
 }
 
 // NewResult wraps a body with pagination metadata. perPage and page mirror the
 // values consumed by Builder.WithQueryParams; Pages is the total page count.
-func NewResult(body interface{}, total, perPage, page int) Result {
+func NewResult(body any, total, perPage, page int) Result {
 	pages := 0
 	if perPage > 0 {
 		pages = (total + perPage - 1) / perPage // ceil(total/perPage)

--- a/query.go
+++ b/query.go
@@ -11,7 +11,7 @@ import (
 
 var timeType = reflect.TypeOf(time.Time{})
 
-func (b *Builder) WithQueryParams(model interface{}, qp map[string]string) (*Builder, error) {
+func (b *Builder) WithQueryParams(model any, qp map[string]string) (*Builder, error) {
 	var page, perPage int
 	var err error
 
@@ -76,7 +76,7 @@ func (b *Builder) parseQueryParam(key string, value string) error {
 	case "in", "not-in": // [in]=1,2 or [not-in]=1,2
 		array := strings.Split(value, ",")
 
-		s := make([]interface{}, len(array))
+		s := make([]any, len(array))
 		for i, v := range array {
 			s[i] = v
 		}
@@ -94,7 +94,7 @@ func (b *Builder) parseQueryParam(key string, value string) error {
 	return nil
 }
 
-func (b *Builder) parseStruct(st interface{}) {
+func (b *Builder) parseStruct(st any) {
 	jsonToDb := make(map[string]string)
 
 	parseStruct(st, jsonToDb, "")
@@ -102,7 +102,7 @@ func (b *Builder) parseStruct(st interface{}) {
 	b.ctx.JsonToDB = jsonToDb
 }
 
-func parseStruct(st interface{}, data map[string]string, sub string) {
+func parseStruct(st any, data map[string]string, sub string) {
 	t := reflect.TypeOf(st)
 	val := reflect.ValueOf(st)
 

--- a/select_where.go
+++ b/select_where.go
@@ -18,20 +18,20 @@ func (b *Builder) OrGroupOn(sub SubBuilderFunc) *Builder {
 	return b.sub(sub, true)
 }
 
-func (b *Builder) Where(key string, operator string, values ...interface{}) *Builder {
+func (b *Builder) Where(key string, operator string, values ...any) *Builder {
 	return b.where(key, operator, values, false, false)
 }
 
-func (b *Builder) OrWhere(key string, operator string, values ...interface{}) *Builder {
+func (b *Builder) OrWhere(key string, operator string, values ...any) *Builder {
 	return b.where(key, operator, values, true, false)
 }
 
 func (b *Builder) On(firstKey string, operator string, secondKey string) *Builder {
-	return b.where(firstKey, operator, []interface{}{secondKey}, false, true)
+	return b.where(firstKey, operator, []any{secondKey}, false, true)
 }
 
 func (b *Builder) OrOn(firstKey string, operator string, secondKey string) *Builder {
-	return b.where(firstKey, operator, []interface{}{secondKey}, true, true)
+	return b.where(firstKey, operator, []any{secondKey}, true, true)
 }
 
 func (b *Builder) sub(sub SubBuilderFunc, isOr bool) *Builder {
@@ -46,7 +46,7 @@ func (b *Builder) sub(sub SubBuilderFunc, isOr bool) *Builder {
 	return b
 }
 
-func (b *Builder) where(key, operator string, values []interface{}, isOr, isOn bool) *Builder {
+func (b *Builder) where(key, operator string, values []any, isOr, isOn bool) *Builder {
 	b.ctx.Where = append(b.ctx.Where, WhereContext{
 		Values: []where{
 			{

--- a/update.go
+++ b/update.go
@@ -20,7 +20,7 @@ type updateContext struct {
 
 type updateValue struct {
 	Column string
-	Value  interface{}
+	Value  any
 }
 
 func NewUpdate(table string) *UpdateBuilder {
@@ -37,7 +37,7 @@ func (u *UpdateBuilder) Dialect(d Dialect) *UpdateBuilder {
 	return u
 }
 
-func (u *UpdateBuilder) Set(column string, value interface{}) *UpdateBuilder {
+func (u *UpdateBuilder) Set(column string, value any) *UpdateBuilder {
 	u.ctx.Value = append(u.ctx.Value, updateValue{Column: column, Value: value})
 	return u
 }
@@ -48,7 +48,7 @@ func (u *UpdateBuilder) Returning(columns ...string) *UpdateBuilder {
 	return u
 }
 
-func (u *UpdateBuilder) Get() (query string, params []interface{}, err error) {
+func (u *UpdateBuilder) Get() (query string, params []any, err error) {
 	query, params, err = u.build()
 	if u.dialect != nil {
 		query = u.dialect.Rebind(query)
@@ -56,7 +56,7 @@ func (u *UpdateBuilder) Get() (query string, params []interface{}, err error) {
 	return query, params, err
 }
 
-func (u *UpdateBuilder) build() (res string, params []interface{}, err error) {
+func (u *UpdateBuilder) build() (res string, params []any, err error) {
 	var result []string
 
 	if u.ctx.Table == "" {
@@ -75,7 +75,7 @@ func (u *UpdateBuilder) build() (res string, params []interface{}, err error) {
 
 	for i, wc := range u.ctx.Where {
 		var r []string
-		var p []interface{}
+		var p []any
 
 		r, p, err = buildWhere(wc, i == 0, false, false)
 		if err != nil {

--- a/update_where.go
+++ b/update_where.go
@@ -18,20 +18,20 @@ func (u *UpdateBuilder) OrGroupOn(sub SubBuilderFunc) *UpdateBuilder {
 	return u.sub(sub, true)
 }
 
-func (u *UpdateBuilder) Where(key string, operator string, values ...interface{}) *UpdateBuilder {
+func (u *UpdateBuilder) Where(key string, operator string, values ...any) *UpdateBuilder {
 	return u.where(key, operator, values, false, false)
 }
 
-func (u *UpdateBuilder) OrWhere(key string, operator string, values ...interface{}) *UpdateBuilder {
+func (u *UpdateBuilder) OrWhere(key string, operator string, values ...any) *UpdateBuilder {
 	return u.where(key, operator, values, true, false)
 }
 
 func (u *UpdateBuilder) On(firstKey string, operator string, secondKey string) *UpdateBuilder {
-	return u.where(firstKey, operator, []interface{}{secondKey}, false, true)
+	return u.where(firstKey, operator, []any{secondKey}, false, true)
 }
 
 func (u *UpdateBuilder) OrOn(firstKey string, operator string, secondKey string) *UpdateBuilder {
-	return u.where(firstKey, operator, []interface{}{secondKey}, true, true)
+	return u.where(firstKey, operator, []any{secondKey}, true, true)
 }
 
 func (u *UpdateBuilder) sub(sub SubBuilderFunc, isOr bool) *UpdateBuilder {
@@ -46,7 +46,7 @@ func (u *UpdateBuilder) sub(sub SubBuilderFunc, isOr bool) *UpdateBuilder {
 	return u
 }
 
-func (u *UpdateBuilder) where(key, operator string, values []interface{}, isOr, isOn bool) *UpdateBuilder {
+func (u *UpdateBuilder) where(key, operator string, values []any, isOr, isOn bool) *UpdateBuilder {
 	u.ctx.Where = append(u.ctx.Where, WhereContext{
 		Values: []where{
 			{


### PR DESCRIPTION
## Phase 5 — Modernisation `interface{}` → `any`

> Stack sur `phase-4-coherence`. Cosmétique, à merger après la Phase 4.

Réécriture mécanique via `gofmt -r 'interface{} -> any' *.go`. Aucun changement de comportement, 30 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)