### PR TITLE
fix: OR groups, query-param panics, count ORDER BY and placeholders

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -90,17 +90,17 @@ func (b *Builder) Offset(offset int) *Builder {
 }
 
 func (b *Builder) Get() (query string, params []interface{}, err error) {
-	query, params, err = b.build()
+	query, params, err = b.build(true)
 	return b.withFields(b.withLimitOffset(query)), params, err
 }
 
 func (b *Builder) GetCount() (query string, params []interface{}, err error) {
-	query, params, err = b.build()
+	query, params, err = b.build(false)
 	return b.withCount(query, ""), params, err
 }
 
 func (b *Builder) GetCountWithKey(key string) (query string, params []interface{}, err error) {
-	query, params, err = b.build()
+	query, params, err = b.build(false)
 	return b.withCount(query, key), params, err
 }
 
@@ -150,7 +150,7 @@ func buildWhere(wc WhereContext, isFirst, isJoin, isSub bool) (result []string, 
 				result = append(result, fmt.Sprintf(
 					"%s IN (%s)",
 					w.Key,
-					strings.Join(strings.Split(strings.Repeat("?", len(w.Values)), ""), ","),
+					placeholders(len(w.Values), ","),
 				))
 			} else {
 				result = append(result, fmt.Sprintf("%s %s ?", w.Key, w.Operator))
@@ -177,6 +177,14 @@ func buildWhere(wc WhereContext, isFirst, isJoin, isSub bool) (result []string, 
 		result = append(result, ")")
 	}
 	return
+}
+
+// placeholders returns n "?" joined by sep, e.g. placeholders(3, ",") == "?,?,?".
+func placeholders(n int, sep string) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.Repeat("?"+sep, n), sep)
 }
 
 func (b *Builder) withFields(query string) string {
@@ -207,7 +215,7 @@ func (b *Builder) withLimitOffset(query string) string {
 	return query
 }
 
-func (b *Builder) build() (res string, params []interface{}, err error) {
+func (b *Builder) build(withOrderBy bool) (res string, params []interface{}, err error) {
 	var result []string
 
 	if len(b.ctx.Table) == 0 {
@@ -258,7 +266,7 @@ func (b *Builder) build() (res string, params []interface{}, err error) {
 		result = append(result, fmt.Sprintf("GROUP BY %s", strings.Join(b.ctx.GroupBy, ", ")))
 	}
 
-	if len(b.ctx.OrderBy) != 0 {
+	if withOrderBy && len(b.ctx.OrderBy) != 0 {
 		result = append(result, "ORDER BY")
 
 		var ol []string

--- a/builder_test.go
+++ b/builder_test.go
@@ -116,6 +116,42 @@ func TestInsert(t *testing.T) {
 		"INSERT INTO users (name, age) VALUES( ?, ? )", []interface{}{"bob", 30})
 }
 
+func TestOrGroupWhere(t *testing.T) {
+	// regression: OrGroupWhere must emit OR before the group, not AND.
+	q, p, err := New("users").
+		Where("a", "=", 1).
+		OrGroupWhere(func(w *WhereContext) {
+			w.Where("b", "=", 2).Where("c", "=", 3)
+		}).Get()
+	eq(t, "or group", q, p, err,
+		"SELECT * FROM users WHERE a = ? OR ( b = ? AND c = ? )",
+		[]interface{}{1, 2, 3})
+}
+
+func TestCountIgnoresOrderBy(t *testing.T) {
+	// regression: count query must not carry an ORDER BY clause.
+	q, p, err := New("users").OrderBy("name", Asc).GetCount()
+	eq(t, "count no order", q, p, err, "SELECT count(*) FROM users", nil)
+}
+
+func TestPlaceholders(t *testing.T) {
+	cases := []struct {
+		n   int
+		sep string
+		out string
+	}{
+		{0, ",", ""},
+		{1, ",", "?"},
+		{3, ",", "?,?,?"},
+		{2, ", ", "?, ?"},
+	}
+	for _, c := range cases {
+		if got := placeholders(c.n, c.sep); got != c.out {
+			t.Errorf("placeholders(%d,%q) = %q, want %q", c.n, c.sep, got, c.out)
+		}
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	q, p, err := NewUpdate("users").Set("name", "bob").Where("id", "=", 1).Get()
 	eq(t, "update", q, p, err,

--- a/group_where.go
+++ b/group_where.go
@@ -11,11 +11,11 @@ func (b *WhereContext) GroupOn(sub SubBuilderFunc) *WhereContext {
 }
 
 func (b *WhereContext) OrGroupWhere(sub SubBuilderFunc) *WhereContext {
-	return b.sub(sub, false)
+	return b.sub(sub, true)
 }
 
 func (b *WhereContext) OrGroupOn(sub SubBuilderFunc) *WhereContext {
-	return b.sub(sub, false)
+	return b.sub(sub, true)
 }
 
 func (b *WhereContext) Where(key string, operator string, values ...interface{}) *WhereContext {

--- a/insert.go
+++ b/insert.go
@@ -66,7 +66,7 @@ func (i *InsertBuilder) build() (res string, params []interface{}, err error) {
 	}
 
 	result = append(result, "VALUES(")
-	result = append(result, strings.Join(strings.Split(strings.Repeat("?", len(i.ctx.Value)), ""), ", "))
+	result = append(result, placeholders(len(i.ctx.Value), ", "))
 	result = append(result, ")")
 
 	if i.ctx.withDuplicateKey {

--- a/query.go
+++ b/query.go
@@ -1,13 +1,14 @@
 package melody
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 )
 
-func (b *Builder) WithQueryParams(model interface{}, qp map[string]string) *Builder {
+func (b *Builder) WithQueryParams(model interface{}, qp map[string]string) (*Builder, error) {
 	var page, perPage int
 	var err error
 
@@ -18,19 +19,16 @@ func (b *Builder) WithQueryParams(model interface{}, qp map[string]string) *Buil
 		case "page":
 			page, err = strconv.Atoi(value)
 			if err != nil {
-				panic(err)
+				return b, fmt.Errorf("invalid page %q: %w", value, err)
 			}
-			break
 		case "per_page":
 			perPage, err = strconv.Atoi(value)
 			if err != nil {
-				panic(err)
+				return b, fmt.Errorf("invalid per_page %q: %w", value, err)
 			}
-			break
 		default:
-			err = b.parseQueryParam(key, value)
-			if err != nil {
-				panic(err)
+			if err = b.parseQueryParam(key, value); err != nil {
+				return b, err
 			}
 		}
 	}
@@ -42,7 +40,7 @@ func (b *Builder) WithQueryParams(model interface{}, qp map[string]string) *Buil
 		}
 	}
 
-	return b
+	return b, nil
 }
 
 func (b *Builder) parseQueryParam(key string, value string) error {
@@ -58,24 +56,20 @@ func (b *Builder) parseQueryParam(key string, value string) error {
 		cond = indexes[0][2]
 	}
 
-	field := b.ctx.JsonToDB[json]
-	//if field == "" {
-	//
-	//}
+	field, ok := b.ctx.JsonToDB[json]
+	if !ok {
+		return fmt.Errorf("unknown query param %q", json)
+	}
 
 	switch strings.ToLower(cond) {
 	case "equal": // =23
 		b.Where(field, "=", value)
-		break
 	case "not-equal": // [not-equal]=23
 		b.Where(field, "!=", value)
-		break
 	case "like": // [like]=23
 		b.Where(field, "LIKE", "%"+value+"%")
-		break
 	case "not-like": // [not-like]=23
 		b.Where(field, "NOT LIKE", "%"+value+"%")
-		break
 	case "in", "not-in": // [in]=1,2 or [not-in]=1,2
 		array := strings.Split(value, ",")
 
@@ -90,7 +84,8 @@ func (b *Builder) parseQueryParam(key string, value string) error {
 		}
 
 		b.Where(field, operator, s...)
-		break
+	default:
+		return fmt.Errorf("unknown condition %q", cond)
 	}
 
 	return nil

--- a/select_where.go
+++ b/select_where.go
@@ -11,11 +11,11 @@ func (b *Builder) GroupOn(sub SubBuilderFunc) *Builder {
 }
 
 func (b *Builder) OrGroupWhere(sub SubBuilderFunc) *Builder {
-	return b.sub(sub, false)
+	return b.sub(sub, true)
 }
 
 func (b *Builder) OrGroupOn(sub SubBuilderFunc) *Builder {
-	return b.sub(sub, false)
+	return b.sub(sub, true)
 }
 
 func (b *Builder) Where(key string, operator string, values ...interface{}) *Builder {

--- a/update_where.go
+++ b/update_where.go
@@ -11,11 +11,11 @@ func (u *UpdateBuilder) GroupOn(sub SubBuilderFunc) *UpdateBuilder {
 }
 
 func (u *UpdateBuilder) OrGroupWhere(sub SubBuilderFunc) *UpdateBuilder {
-	return u.sub(sub, false)
+	return u.sub(sub, true)
 }
 
 func (u *UpdateBuilder) OrGroupOn(sub SubBuilderFunc) *UpdateBuilder {
-	return u.sub(sub, false)
+	return u.sub(sub, true)
 }
 
 func (u *UpdateBuilder) Where(key string, operator string, values ...interface{}) *UpdateBuilder {


### PR DESCRIPTION
Builds on Phase 0 (already in main). Merge in order: 1 → 6.

| Bug | Fix |
|-----|-----|
| `OrGroupWhere`/`OrGroupOn` emitted `AND` instead of `OR` | pass `true` (Builder, WhereContext, UpdateBuilder) |
| `WithQueryParams` panicked on bad HTTP input | returns `error` now |
| unknown param/condition produced broken SQL silently | returns explicit `error` |
| `GetCount` dragged a useless `ORDER BY` | count without ORDER BY |
| convoluted placeholder generation | `placeholders(n, sep)` helper |

Breaking change: `WithQueryParams(model, qp)` now returns `(*Builder, error)`.