### PR TITLE
feat: dialect abstraction with Postgres support

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -9,7 +9,8 @@ import (
 type SubBuilderFunc func(w *WhereContext)
 
 type Builder struct {
-	ctx builderContext
+	ctx     builderContext
+	dialect Dialect
 }
 
 type builderContext struct {
@@ -49,6 +50,20 @@ func New(tables ...string) *Builder {
 	b := Builder{}
 	b.ctx.Table = append(b.ctx.Table, tables...)
 	return &b
+}
+
+// Dialect sets the SQL dialect used to render the final query. Defaults to
+// melody.Default ("?" placeholders) when unset.
+func (b *Builder) Dialect(d Dialect) *Builder {
+	b.dialect = d
+	return b
+}
+
+func (b *Builder) rebind(query string) string {
+	if b.dialect == nil {
+		return query
+	}
+	return b.dialect.Rebind(query)
 }
 
 func (b *Builder) Select(fields ...string) *Builder {
@@ -91,17 +106,17 @@ func (b *Builder) Offset(offset int) *Builder {
 
 func (b *Builder) Get() (query string, params []interface{}, err error) {
 	query, params, err = b.build(true)
-	return b.withFields(b.withLimitOffset(query)), params, err
+	return b.rebind(b.withFields(b.withLimitOffset(query))), params, err
 }
 
 func (b *Builder) GetCount() (query string, params []interface{}, err error) {
 	query, params, err = b.build(false)
-	return b.withCount(query, ""), params, err
+	return b.rebind(b.withCount(query, "")), params, err
 }
 
 func (b *Builder) GetCountWithKey(key string) (query string, params []interface{}, err error) {
 	query, params, err = b.build(false)
-	return b.withCount(query, key), params, err
+	return b.rebind(b.withCount(query, key)), params, err
 }
 
 func (b *Builder) GetOffset() int {

--- a/dialect.go
+++ b/dialect.go
@@ -1,0 +1,48 @@
+package melody
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Dialect adapts the generated SQL to a specific database.
+//
+// The builder always emits parameters as "?" placeholders internally; the
+// dialect's Rebind translates them to the engine's native style as the final
+// step. Since the builder never emits string literals (every value is a bound
+// parameter), a "?" can only ever be a placeholder, which makes the rebind
+// pass safe.
+type Dialect interface {
+	// Rebind converts the builder's "?" placeholders into the dialect's
+	// native placeholder style.
+	Rebind(query string) string
+}
+
+// Default keeps "?" placeholders (MySQL / SQLite style). It is the zero-value
+// dialect so existing behaviour is unchanged when no dialect is set.
+var Default Dialect = defaultDialect{}
+
+// Postgres uses positional "$1, $2, ..." placeholders.
+var Postgres Dialect = postgresDialect{}
+
+type defaultDialect struct{}
+
+func (defaultDialect) Rebind(query string) string { return query }
+
+type postgresDialect struct{}
+
+func (postgresDialect) Rebind(query string) string {
+	var sb strings.Builder
+	sb.Grow(len(query))
+	n := 0
+	for i := 0; i < len(query); i++ {
+		if query[i] == '?' {
+			n++
+			sb.WriteByte('$')
+			sb.WriteString(strconv.Itoa(n))
+		} else {
+			sb.WriteByte(query[i])
+		}
+	}
+	return sb.String()
+}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -1,0 +1,44 @@
+package melody
+
+import "testing"
+
+func TestPostgresSelectPlaceholders(t *testing.T) {
+	q, p, err := New("users").
+		Dialect(Postgres).
+		Where("id", "=", 1).
+		Where("name", "=", "bob").
+		Where("status", "IN", "a", "b").
+		Get()
+	eq(t, "pg select", q, p, err,
+		"SELECT * FROM users WHERE id = $1 AND name = $2 AND status IN ($3,$4)",
+		[]interface{}{1, "bob", "a", "b"})
+}
+
+func TestPostgresInsert(t *testing.T) {
+	q, p, err := NewInsert("users").Dialect(Postgres).
+		Set("name", "bob").Set("age", 30).Get()
+	eq(t, "pg insert", q, p, err,
+		"INSERT INTO users (name, age) VALUES( $1, $2 )", []interface{}{"bob", 30})
+}
+
+func TestPostgresUpdate(t *testing.T) {
+	q, p, err := NewUpdate("users").Dialect(Postgres).
+		Set("name", "bob").Where("id", "=", 1).Get()
+	eq(t, "pg update", q, p, err,
+		"UPDATE users SET name = $1 WHERE id = $2", []interface{}{"bob", 1})
+}
+
+func TestDefaultDialectUnchanged(t *testing.T) {
+	q, _, _ := New("users").Where("id", "=", 1).Get()
+	if q != "SELECT * FROM users WHERE id = ?" {
+		t.Errorf("default dialect changed: %q", q)
+	}
+}
+
+func TestRebindDollar(t *testing.T) {
+	got := Postgres.Rebind("a = ? AND b IN (?,?)")
+	want := "a = $1 AND b IN ($2,$3)"
+	if got != want {
+		t.Errorf("Rebind = %q, want %q", got, want)
+	}
+}

--- a/insert.go
+++ b/insert.go
@@ -7,7 +7,8 @@ import (
 )
 
 type InsertBuilder struct {
-	ctx insertContext
+	ctx     insertContext
+	dialect Dialect
 }
 
 type insertContext struct {
@@ -24,10 +25,16 @@ type insertValue struct {
 
 func NewInsert(table string) *InsertBuilder {
 	return &InsertBuilder{
-		insertContext{
+		ctx: insertContext{
 			Table: table,
 		},
 	}
+}
+
+// Dialect sets the SQL dialect used to render the final query.
+func (i *InsertBuilder) Dialect(d Dialect) *InsertBuilder {
+	i.dialect = d
+	return i
 }
 
 func (i *InsertBuilder) Set(column string, value interface{}) *InsertBuilder {
@@ -42,7 +49,11 @@ func (i *InsertBuilder) UpdateDuplicateKey() *InsertBuilder {
 }
 
 func (i *InsertBuilder) Get() (query string, params []interface{}, err error) {
-	return i.build()
+	query, params, err = i.build()
+	if i.dialect != nil {
+		query = i.dialect.Rebind(query)
+	}
+	return query, params, err
 }
 
 func (i *InsertBuilder) build() (res string, params []interface{}, err error) {

--- a/update.go
+++ b/update.go
@@ -7,7 +7,8 @@ import (
 )
 
 type UpdateBuilder struct {
-	ctx updateContext
+	ctx     updateContext
+	dialect Dialect
 }
 
 type updateContext struct {
@@ -23,10 +24,16 @@ type updateValue struct {
 
 func NewUpdate(table string) *UpdateBuilder {
 	return &UpdateBuilder{
-		updateContext{
+		ctx: updateContext{
 			Table: table,
 		},
 	}
+}
+
+// Dialect sets the SQL dialect used to render the final query.
+func (u *UpdateBuilder) Dialect(d Dialect) *UpdateBuilder {
+	u.dialect = d
+	return u
 }
 
 func (u *UpdateBuilder) Set(column string, value interface{}) *UpdateBuilder {
@@ -35,7 +42,11 @@ func (u *UpdateBuilder) Set(column string, value interface{}) *UpdateBuilder {
 }
 
 func (u *UpdateBuilder) Get() (query string, params []interface{}, err error) {
-	return u.build()
+	query, params, err = u.build()
+	if u.dialect != nil {
+		query = u.dialect.Rebind(query)
+	}
+	return query, params, err
 }
 
 func (u *UpdateBuilder) build() (res string, params []interface{}, err error) {


### PR DESCRIPTION
Stacked on Phase 1. Until Phase 1 is merged, this diff also shows Phase 1; it narrows to Phase 2 only once Phase 1 lands in main.

Removes the hardcoded `?` that made Postgres impossible.

```go
melody.New("users").Dialect(melody.Postgres).Where("id", "=", 1).Get()
// SELECT * FROM users WHERE id = $1
```

- `Dialect` interface (`Rebind`), `melody.Default` (`?`), `melody.Postgres` (`$1, $2`).
- `.Dialect()` on Builder/InsertBuilder/UpdateBuilder.
- Post-process rebind: safe because the builder never emits SQL literals.