### PR TITLE
feat: multi-row INSERT via AddRow

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ melody.NewInsert("users").Dialect(melody.Postgres).
     Get()
 // INSERT INTO users (name, age) VALUES( $1, $2 ) RETURNING id
 
+melody.NewInsert("users").
+    Set("name", "bob").Set("age", 30).
+    AddRow().
+    Set("name", "alice").Set("age", 25).
+    Get()
+// INSERT INTO users (name, age) VALUES (?, ?), (?, ?)
+
 melody.NewUpdate("users").
     Set("name", "bob").
     Where("id", "=", 1).

--- a/insert.go
+++ b/insert.go
@@ -12,16 +12,11 @@ type InsertBuilder struct {
 }
 
 type insertContext struct {
-	Table            string
-	Value            []insertValue
-	withDuplicateKey bool
-	Returning        []string
-}
-
-type insertValue struct {
-	Column           string
-	Value            any
-	withDuplicateKey bool
+	Table     string
+	Columns   []string
+	Rows      [][]any
+	DupKeys   []string // columns to update on ON DUPLICATE KEY UPDATE
+	Returning []string
 }
 
 func NewInsert(table string) *InsertBuilder {
@@ -38,10 +33,24 @@ func (i *InsertBuilder) Dialect(d Dialect) *InsertBuilder {
 	return i
 }
 
-// ponytail: single-row insert only. Multi-row VALUES (...),(...) needs an
-// AddRow-style API redesign of InsertBuilder; add when batch inserts are needed.
+// Set adds a column/value to the current row. Column names are taken from the
+// first row; subsequent rows (see AddRow) must Set the same columns in order.
 func (i *InsertBuilder) Set(column string, value any) *InsertBuilder {
-	i.ctx.Value = append(i.ctx.Value, insertValue{Column: column, Value: value})
+	if len(i.ctx.Rows) == 0 {
+		i.ctx.Rows = append(i.ctx.Rows, nil)
+	}
+	last := len(i.ctx.Rows) - 1
+	if last == 0 {
+		i.ctx.Columns = append(i.ctx.Columns, column)
+	}
+	i.ctx.Rows[last] = append(i.ctx.Rows[last], value)
+	return i
+}
+
+// AddRow starts a new row for a multi-row INSERT. The following Set calls fill
+// it, in the same column order as the first row.
+func (i *InsertBuilder) AddRow() *InsertBuilder {
+	i.ctx.Rows = append(i.ctx.Rows, nil)
 	return i
 }
 
@@ -51,14 +60,22 @@ func (i *InsertBuilder) Returning(columns ...string) *InsertBuilder {
 	return i
 }
 
+// UpdateDuplicateKey flags the most recently Set column for an
+// ON DUPLICATE KEY UPDATE clause (MySQL).
+// ponytail: dup-key uses the first row's value; combining it with multi-row
+// inserts is undefined — use VALUES(col) by hand if you need that.
 func (i *InsertBuilder) UpdateDuplicateKey() *InsertBuilder {
-	i.ctx.withDuplicateKey = true
-	i.ctx.Value[len(i.ctx.Value)-1].withDuplicateKey = true
+	if n := len(i.ctx.Columns); n > 0 {
+		i.ctx.DupKeys = append(i.ctx.DupKeys, i.ctx.Columns[n-1])
+	}
 	return i
 }
 
 func (i *InsertBuilder) Get() (query string, params []any, err error) {
 	query, params, err = i.build()
+	if err != nil {
+		return query, params, err
+	}
 	if i.dialect != nil {
 		query = i.dialect.Rebind(query)
 	}
@@ -66,40 +83,42 @@ func (i *InsertBuilder) Get() (query string, params []any, err error) {
 }
 
 func (i *InsertBuilder) build() (res string, params []any, err error) {
-	var result []string
-
 	if i.ctx.Table == "" {
 		return res, params, errors.New("one table need to be defined")
 	}
-
-	result = append(result, fmt.Sprintf("INSERT INTO %s", i.ctx.Table))
-
-	var columns []string
-	for _, v := range i.ctx.Value {
-		columns = append(columns, v.Column)
+	if len(i.ctx.Rows) == 0 {
+		return res, params, errors.New("no values to insert")
 	}
 
-	result = append(result, fmt.Sprintf("(%s)", strings.Join(columns, ", ")))
-
-	for _, v := range i.ctx.Value {
-		params = append(params, v.Value)
+	n := len(i.ctx.Columns)
+	result := []string{
+		fmt.Sprintf("INSERT INTO %s", i.ctx.Table),
+		fmt.Sprintf("(%s)", strings.Join(i.ctx.Columns, ", ")),
 	}
 
-	result = append(result, "VALUES(")
-	result = append(result, placeholders(len(i.ctx.Value), ", "))
-	result = append(result, ")")
-
-	if i.ctx.withDuplicateKey {
-		var resultOnUpdate []string
-		for _, v := range i.ctx.Value {
-			if v.withDuplicateKey {
-				resultOnUpdate = append(resultOnUpdate, fmt.Sprintf("%s = ?", v.Column))
-				params = append(params, v.Value)
+	if len(i.ctx.Rows) == 1 {
+		result = append(result, "VALUES(", placeholders(n, ", "), ")")
+		params = append(params, i.ctx.Rows[0]...)
+	} else {
+		var rows []string
+		for r, row := range i.ctx.Rows {
+			if len(row) != n {
+				return res, params, fmt.Errorf("row %d has %d values, expected %d", r, len(row), n)
 			}
+			rows = append(rows, "("+placeholders(n, ", ")+")")
+			params = append(params, row...)
 		}
+		result = append(result, "VALUES "+strings.Join(rows, ", "))
+	}
 
+	if len(i.ctx.DupKeys) > 0 {
+		var ups []string
+		for _, col := range i.ctx.DupKeys {
+			ups = append(ups, fmt.Sprintf("%s = ?", col))
+			params = append(params, i.ctx.Rows[0][indexOf(i.ctx.Columns, col)])
+		}
 		result = append(result, "ON DUPLICATE KEY UPDATE")
-		result = append(result, strings.Join(resultOnUpdate, ", "))
+		result = append(result, strings.Join(ups, ", "))
 	}
 
 	if len(i.ctx.Returning) != 0 {
@@ -107,4 +126,13 @@ func (i *InsertBuilder) build() (res string, params []any, err error) {
 	}
 
 	return strings.Join(result, " "), params, nil
+}
+
+func indexOf(ss []string, s string) int {
+	for i, v := range ss {
+		if v == s {
+			return i
+		}
+	}
+	return 0
 }

--- a/insert_test.go
+++ b/insert_test.go
@@ -1,0 +1,51 @@
+package melody
+
+import "testing"
+
+func TestInsertMultiRow(t *testing.T) {
+	q, p, err := NewInsert("users").
+		Set("name", "bob").Set("age", 30).
+		AddRow().
+		Set("name", "alice").Set("age", 25).
+		Get()
+	eq(t, "multi row", q, p, err,
+		"INSERT INTO users (name, age) VALUES (?, ?), (?, ?)",
+		[]any{"bob", 30, "alice", 25})
+}
+
+func TestInsertMultiRowPostgres(t *testing.T) {
+	q, p, err := NewInsert("users").Dialect(Postgres).
+		Set("name", "bob").
+		AddRow().Set("name", "alice").
+		Get()
+	eq(t, "multi row pg", q, p, err,
+		"INSERT INTO users (name) VALUES ($1), ($2)",
+		[]any{"bob", "alice"})
+}
+
+func TestInsertMultiRowMismatch(t *testing.T) {
+	_, _, err := NewInsert("users").
+		Set("name", "bob").Set("age", 30).
+		AddRow().Set("name", "alice"). // missing age
+		Get()
+	if err == nil {
+		t.Fatal("expected error on row value count mismatch")
+	}
+}
+
+func TestInsertNoValues(t *testing.T) {
+	_, _, err := NewInsert("users").Get()
+	if err == nil {
+		t.Fatal("expected error when no values set")
+	}
+}
+
+func TestInsertDuplicateKey(t *testing.T) {
+	q, p, err := NewInsert("users").
+		Set("id", 1).
+		Set("name", "bob").UpdateDuplicateKey().
+		Get()
+	eq(t, "dup key", q, p, err,
+		"INSERT INTO users (id, name) VALUES( ?, ? ) ON DUPLICATE KEY UPDATE name = ?",
+		[]any{1, "bob", "bob"})
+}


### PR DESCRIPTION
Stacked on Phase 5. Merge in order: 1 → 6.

`InsertBuilder` moves from a flat value list to a columns + rows model.

```go
melody.NewInsert("users").
    Set("name", "bob").Set("age", 30).
    AddRow().
    Set("name", "alice").Set("age", 25).
    Get()
// INSERT INTO users (name, age) VALUES (?, ?), (?, ?)
```

- `AddRow()` starts a new row; `Set` fills the current one.
- Single-row rendering unchanged.
- New errors: row value-count mismatch, empty insert.