### PR TITLE
ci: run go vet and tests on push and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - run: go vet ./...
+      - run: go test -race ./...


### PR DESCRIPTION
Adds a GitHub Actions workflow running `go vet` and `go test -race` on every push to main and every PR. Until now the 35 tests ran nowhere automated.