### PR TITLE
feat: dialect-aware upsert + Postgres and SQLite dialects

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,22 @@ melody.NewDelete("users").
 // DELETE FROM users WHERE id = ?
 ```
 
+### Upsert
+
+The conflict clause is rendered by the dialect:
+
+```go
+melody.NewInsert("users").Dialect(melody.Postgres).
+    Set("id", 1).
+    Set("name", "bob").UpdateDuplicateKey().
+    OnConflict("id").
+    Get()
+// INSERT INTO users (id, name) VALUES( $1, $2 )
+//   ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name
+
+// default dialect: ... ON DUPLICATE KEY UPDATE name = ?
+```
+
 ## HTTP query params → WHERE
 
 Map JSON field names (from your model's `json`/`db` tags) to columns and build a
@@ -135,9 +151,23 @@ result := melody.NewResult(users, total, perPage, page)
 // result.Meta.Pages computed as ceil(total/perPage)
 ```
 
+## Execution
+
+melody is a pure query builder — it never touches the database. Pass its output
+to your own driver:
+
+```go
+q, params, err := melody.New("users").
+    Dialect(melody.Postgres).
+    Where("id", "=", 1).
+    Get()
+
+rows, err := db.Query(q, params...) // database/sql, pgx, ... your call
+```
+
 ## Status
 
-- `database/sql`-style output: `(query string, params []interface{}, err error)` — bring your own driver.
+- Output: `(query string, params []any, err error)` — bring your own driver.
 - Identifiers passed to `Where`/`On`/`OrderBy`/`Select` are emitted as-is; treat them
   as developer-controlled (same trust level as hand-written SQL). User input belongs in
   values (bound params) or in `WithQueryParams` (mapped columns).

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Every value is bound as a parameter — melody never interpolates values into th
 
 The builder emits `?` placeholders internally; the dialect rewrites them on render.
 
-| Dialect            | Placeholders | Notes                              |
-|--------------------|--------------|------------------------------------|
-| `melody.Default`   | `?`          | MySQL / SQLite. Used when unset.   |
-| `melody.Postgres`  | `$1, $2, …`  | Set via `.Dialect(melody.Postgres)`|
+| Dialect           | Placeholders | Upsert                            |
+|-------------------|--------------|-----------------------------------|
+| `melody.Default`  | `?`          | `ON DUPLICATE KEY UPDATE` (MySQL) |
+| `melody.Postgres` | `$1, $2, …`  | `ON CONFLICT … DO UPDATE`         |
+| `melody.SQLite`   | `?`          | `ON CONFLICT … DO UPDATE`         |
 
 Implement `melody.Dialect` to add your own.
 

--- a/dialect.go
+++ b/dialect.go
@@ -31,6 +31,10 @@ var Default Dialect = defaultDialect{}
 // Postgres uses positional "$1, $2, ..." placeholders.
 var Postgres Dialect = postgresDialect{}
 
+// SQLite keeps "?" placeholders but uses the Postgres-style
+// ON CONFLICT ... DO UPDATE SET upsert (not MySQL's ON DUPLICATE KEY).
+var SQLite Dialect = sqliteDialect{}
+
 type defaultDialect struct{}
 
 func (defaultDialect) Rebind(query string) string { return query }
@@ -62,6 +66,20 @@ func (postgresDialect) Rebind(query string) string {
 }
 
 func (postgresDialect) UpsertClause(conflict, update []string) (string, bool) {
+	return onConflictClause(conflict, update)
+}
+
+type sqliteDialect struct{}
+
+func (sqliteDialect) Rebind(query string) string { return query }
+
+func (sqliteDialect) UpsertClause(conflict, update []string) (string, bool) {
+	return onConflictClause(conflict, update)
+}
+
+// onConflictClause renders the Postgres/SQLite upsert clause. It needs no extra
+// params (values come from EXCLUDED).
+func onConflictClause(conflict, update []string) (string, bool) {
 	sets := make([]string, len(update))
 	for i, c := range update {
 		sets[i] = c + " = EXCLUDED." + c

--- a/dialect.go
+++ b/dialect.go
@@ -16,6 +16,12 @@ type Dialect interface {
 	// Rebind converts the builder's "?" placeholders into the dialect's
 	// native placeholder style.
 	Rebind(query string) string
+	// UpsertClause renders the "update on conflict" clause of an INSERT.
+	// conflict holds the columns forming the unique constraint (Postgres needs
+	// them; MySQL ignores them); update holds the columns to overwrite.
+	// withParams reports whether the caller must append one bound value per
+	// update column (MySQL "col = ?"); Postgres uses EXCLUDED and needs none.
+	UpsertClause(conflict, update []string) (clause string, withParams bool)
 }
 
 // Default keeps "?" placeholders (MySQL / SQLite style). It is the zero-value
@@ -28,6 +34,14 @@ var Postgres Dialect = postgresDialect{}
 type defaultDialect struct{}
 
 func (defaultDialect) Rebind(query string) string { return query }
+
+func (defaultDialect) UpsertClause(_, update []string) (string, bool) {
+	sets := make([]string, len(update))
+	for i, c := range update {
+		sets[i] = c + " = ?"
+	}
+	return "ON DUPLICATE KEY UPDATE " + strings.Join(sets, ", "), true
+}
 
 type postgresDialect struct{}
 
@@ -45,4 +59,16 @@ func (postgresDialect) Rebind(query string) string {
 		}
 	}
 	return sb.String()
+}
+
+func (postgresDialect) UpsertClause(conflict, update []string) (string, bool) {
+	sets := make([]string, len(update))
+	for i, c := range update {
+		sets[i] = c + " = EXCLUDED." + c
+	}
+	target := ""
+	if len(conflict) > 0 {
+		target = " (" + strings.Join(conflict, ", ") + ")"
+	}
+	return "ON CONFLICT" + target + " DO UPDATE SET " + strings.Join(sets, ", "), false
 }

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -42,3 +42,25 @@ func TestRebindDollar(t *testing.T) {
 		t.Errorf("Rebind = %q, want %q", got, want)
 	}
 }
+
+func TestPostgresUpsert(t *testing.T) {
+	q, p, err := NewInsert("users").Dialect(Postgres).
+		Set("id", 1).
+		Set("name", "bob").UpdateDuplicateKey().
+		OnConflict("id").
+		Get()
+	eq(t, "pg upsert", q, p, err,
+		"INSERT INTO users (id, name) VALUES( $1, $2 ) ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name",
+		[]any{1, "bob"})
+}
+
+func TestDefaultUpsertUnchanged(t *testing.T) {
+	// regression: default dialect still emits MySQL ON DUPLICATE KEY UPDATE
+	q, p, err := NewInsert("users").
+		Set("id", 1).
+		Set("name", "bob").UpdateDuplicateKey().
+		Get()
+	eq(t, "default upsert", q, p, err,
+		"INSERT INTO users (id, name) VALUES( ?, ? ) ON DUPLICATE KEY UPDATE name = ?",
+		[]any{1, "bob", "bob"})
+}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -64,3 +64,22 @@ func TestDefaultUpsertUnchanged(t *testing.T) {
 		"INSERT INTO users (id, name) VALUES( ?, ? ) ON DUPLICATE KEY UPDATE name = ?",
 		[]any{1, "bob", "bob"})
 }
+
+func TestSQLiteUpsert(t *testing.T) {
+	// SQLite: "?" placeholders + ON CONFLICT (like Postgres, unlike MySQL)
+	q, p, err := NewInsert("users").Dialect(SQLite).
+		Set("id", 1).
+		Set("name", "bob").UpdateDuplicateKey().
+		OnConflict("id").
+		Get()
+	eq(t, "sqlite upsert", q, p, err,
+		"INSERT INTO users (id, name) VALUES( ?, ? ) ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name",
+		[]any{1, "bob"})
+}
+
+func TestSQLiteSelectKeepsQuestionMarks(t *testing.T) {
+	q, _, _ := New("users").Dialect(SQLite).Where("id", "=", 1).Get()
+	if q != "SELECT * FROM users WHERE id = ?" {
+		t.Errorf("sqlite should keep ? placeholders, got %q", q)
+	}
+}

--- a/insert.go
+++ b/insert.go
@@ -12,11 +12,12 @@ type InsertBuilder struct {
 }
 
 type insertContext struct {
-	Table     string
-	Columns   []string
-	Rows      [][]any
-	DupKeys   []string // columns to update on ON DUPLICATE KEY UPDATE
-	Returning []string
+	Table          string
+	Columns        []string
+	Rows           [][]any
+	DupKeys        []string // columns to overwrite on conflict
+	ConflictTarget []string // unique columns the conflict is detected on (Postgres)
+	Returning      []string
 }
 
 func NewInsert(table string) *InsertBuilder {
@@ -60,15 +61,30 @@ func (i *InsertBuilder) Returning(columns ...string) *InsertBuilder {
 	return i
 }
 
-// UpdateDuplicateKey flags the most recently Set column for an
-// ON DUPLICATE KEY UPDATE clause (MySQL).
-// ponytail: dup-key uses the first row's value; combining it with multi-row
-// inserts is undefined — use VALUES(col) by hand if you need that.
+// UpdateDuplicateKey flags the most recently Set column to be overwritten on
+// conflict. The dialect decides the syntax: ON DUPLICATE KEY UPDATE (default)
+// or ON CONFLICT ... DO UPDATE (Postgres — set the target with OnConflict).
+// ponytail: uses the first row's value; combining with multi-row inserts is
+// undefined — write VALUES(col)/EXCLUDED.col by hand if you need that.
 func (i *InsertBuilder) UpdateDuplicateKey() *InsertBuilder {
 	if n := len(i.ctx.Columns); n > 0 {
 		i.ctx.DupKeys = append(i.ctx.DupKeys, i.ctx.Columns[n-1])
 	}
 	return i
+}
+
+// OnConflict sets the unique columns the conflict is detected on. Required by
+// Postgres (ON CONFLICT (cols)); ignored by the default dialect.
+func (i *InsertBuilder) OnConflict(columns ...string) *InsertBuilder {
+	i.ctx.ConflictTarget = append(i.ctx.ConflictTarget, columns...)
+	return i
+}
+
+func (i *InsertBuilder) dia() Dialect {
+	if i.dialect == nil {
+		return Default
+	}
+	return i.dialect
 }
 
 func (i *InsertBuilder) Get() (query string, params []any, err error) {
@@ -112,13 +128,13 @@ func (i *InsertBuilder) build() (res string, params []any, err error) {
 	}
 
 	if len(i.ctx.DupKeys) > 0 {
-		var ups []string
-		for _, col := range i.ctx.DupKeys {
-			ups = append(ups, fmt.Sprintf("%s = ?", col))
-			params = append(params, i.ctx.Rows[0][indexOf(i.ctx.Columns, col)])
+		clause, withParams := i.dia().UpsertClause(i.ctx.ConflictTarget, i.ctx.DupKeys)
+		result = append(result, clause)
+		if withParams {
+			for _, col := range i.ctx.DupKeys {
+				params = append(params, i.ctx.Rows[0][indexOf(i.ctx.Columns, col)])
+			}
 		}
-		result = append(result, "ON DUPLICATE KEY UPDATE")
-		result = append(result, strings.Join(ups, ", "))
 	}
 
 	if len(i.ctx.Returning) != 0 {


### PR DESCRIPTION
Makes melody genuinely engine-agnostic by moving the conflict clause into the Dialect, and adds a first-class SQLite dialect.

| Dialect | Placeholders | Upsert |
|---|---|---|
| `melody.Default` | `?` | `ON DUPLICATE KEY UPDATE` (MySQL) |
| `melody.Postgres` | `$1, $2` | `ON CONFLICT … DO UPDATE` |
| `melody.SQLite` | `?` | `ON CONFLICT … DO UPDATE` |

```go
melody.NewInsert("users").Dialect(melody.SQLite).
    Set("id", 1).
    Set("name", "bob").UpdateDuplicateKey().
    OnConflict("id").
    Get()
// INSERT INTO users (id, name) VALUES( ?, ? ) ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name
```

- `Dialect.UpsertClause(conflict, update)` renders the conflict clause per engine.
- `InsertBuilder.OnConflict(cols...)` sets the Postgres/SQLite conflict target.
- Postgres and SQLite share the `ON CONFLICT` renderer; default stays MySQL (regression-tested).
- README: dialect table, upsert example, pure-builder execution note.

Covers a project that targets both Postgres and SQLite. Note: adds a method to the public `Dialect` interface — breaking for external implementers, fold into the v2 tag.