### PR TITLE
feat: Melody factory to preset a dialect once

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ The builder emits `?` placeholders internally; the dialect rewrites them on rend
 
 Implement `melody.Dialect` to add your own.
 
+### Set the dialect once
+
+Instead of repeating `.Dialect()` on every query, configure it once with a
+factory and keep it around (e.g. a package var):
+
+```go
+m := melody.With(melody.Postgres)
+
+m.New("users").Where("id", "=", 1).Get()       // SELECT ... WHERE id = $1
+m.NewInsert("users").Set("name", "bob").Get()  // INSERT ... VALUES( $1 )
+```
+
+The package-level `New`/`NewInsert`/… still work, and a factory builder can
+still override per query with a further `.Dialect()`.
+
 ## SELECT
 
 ```go

--- a/melody.go
+++ b/melody.go
@@ -1,0 +1,35 @@
+package melody
+
+// Melody is a builder factory pre-configured with a dialect, so you set the
+// dialect once at startup instead of repeating .Dialect() on every query.
+//
+//	m := melody.With(melody.Postgres) // keep this around (e.g. a package var)
+//	m.New("users").Where("id", "=", 1).Get()
+//	m.NewInsert("users").Set("name", "bob").Get()
+//
+// The package-level New/NewInsert/... still work unchanged; and any builder
+// returned here can override the dialect with a further .Dialect() call.
+type Melody struct {
+	dialect Dialect
+}
+
+// With returns a factory whose builders default to d.
+func With(d Dialect) *Melody {
+	return &Melody{dialect: d}
+}
+
+func (m *Melody) New(tables ...string) *Builder {
+	return New(tables...).Dialect(m.dialect)
+}
+
+func (m *Melody) NewInsert(table string) *InsertBuilder {
+	return NewInsert(table).Dialect(m.dialect)
+}
+
+func (m *Melody) NewUpdate(table string) *UpdateBuilder {
+	return NewUpdate(table).Dialect(m.dialect)
+}
+
+func (m *Melody) NewDelete(table string) *DeleteBuilder {
+	return NewDelete(table).Dialect(m.dialect)
+}

--- a/melody_test.go
+++ b/melody_test.go
@@ -1,0 +1,35 @@
+package melody
+
+import "testing"
+
+func TestMelodyFactoryAppliesDialect(t *testing.T) {
+	m := With(Postgres)
+
+	q, _, _ := m.New("users").Where("id", "=", 1).Get()
+	if q != "SELECT * FROM users WHERE id = $1" {
+		t.Errorf("New: %q", q)
+	}
+
+	qi, _, _ := m.NewInsert("users").Set("name", "bob").Get()
+	if qi != "INSERT INTO users (name) VALUES( $1 )" {
+		t.Errorf("NewInsert: %q", qi)
+	}
+
+	qu, _, _ := m.NewUpdate("users").Set("name", "bob").Where("id", "=", 1).Get()
+	if qu != "UPDATE users SET name = $1 WHERE id = $2" {
+		t.Errorf("NewUpdate: %q", qu)
+	}
+
+	qd, _, _ := m.NewDelete("users").Where("id", "=", 1).Get()
+	if qd != "DELETE FROM users WHERE id = $1" {
+		t.Errorf("NewDelete: %q", qd)
+	}
+}
+
+func TestMelodyFactoryPerQueryOverride(t *testing.T) {
+	// a factory builder can still override the dialect per query
+	q, _, _ := With(Postgres).New("users").Dialect(Default).Where("id", "=", 1).Get()
+	if q != "SELECT * FROM users WHERE id = ?" {
+		t.Errorf("override: %q", q)
+	}
+}


### PR DESCRIPTION
Lets you set the dialect once instead of repeating `.Dialect()` on every query — while keeping the current way fully working.

```go
m := melody.With(melody.Postgres) // keep around, e.g. a package var

m.New("users").Where("id", "=", 1).Get()       // SELECT ... WHERE id = $1
m.NewInsert("users").Set("name", "bob").Get()  // INSERT ... VALUES( $1 )
m.NewUpdate("users")... ; m.NewDelete("users")...
```

- No mutable package global (avoids test pollution / multi-DB hazards): you create an instance and store it yourself.
- Package-level `New`/`NewInsert`/… untouched.
- A factory builder can still override per query with a further `.Dialect()` (tested).

Independent of #20/#21 — branches off main.