### PR TITLE
chore: move module path to /v2 for the v2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 🎶 Build your SQL queries like a melody — a small, dialect-agnostic query builder for Go.
 
 ```bash
-go get github.com/ermos/melody
+go get github.com/ermos/melody/v2
 ```
 
 ## Quick start
 
 ```go
-import "github.com/ermos/melody"
+import "github.com/ermos/melody/v2" // imported as package "melody"
 
 q, params, err := melody.New("users").
     Dialect(melody.Postgres).

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ermos/melody
+module github.com/ermos/melody/v2
 
 go 1.21


### PR DESCRIPTION
Adds the `/v2` suffix to the module path so a `v2.0.0` tag resolves through the Go module proxy.

- `go.mod`: `github.com/ermos/melody` -> `github.com/ermos/melody/v2`
- README: install + import path updated (package is still imported as `melody`)
- No code changes; no internal self-imports to touch.

After this merges, the `v2.0.0` tag must be (re)created on the merge commit — the previous tag was deleted because it pointed at a pre-/v2 go.mod.