### PR TITLE
feat: raw predicates/expressions, IS NULL, ON CONFLICT DO NOTHING

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ melody.New("users").
 // ... WHERE status IN (?,?) OR ( age > ? AND vip = ? )
 ```
 
+### IS NULL / raw predicates
+
+```go
+melody.New("users").
+    WhereNull("deleted_at").                         // ... WHERE deleted_at IS NULL
+    WhereNotNull("email").                           // AND email IS NOT NULL
+    WhereRaw("LOWER(name) LIKE LOWER(?)", "%bob%").  // AND LOWER(name) LIKE LOWER(?)
+    WhereRaw("EXISTS (SELECT 1 FROM orders o WHERE o.user_id = users.id)").
+    OrderByRaw("RANDOM()").
+    Get()
+```
+
+`WhereRaw` (and `OrWhereRaw`) is the escape hatch for anything the typed API
+can't express — function calls, `EXISTS`/`NOT EXISTS`, custom `IN`, etc. Its `?`
+args are bound like any other value.
+
 ### JOIN
 
 ```go
@@ -116,6 +132,13 @@ melody.NewUpdate("users").
     Get()
 // UPDATE users SET name = ? WHERE id = ?
 
+melody.NewUpdate("posts").
+    SetRaw("views", "views + 1").              // column-relative / expression
+    SetRaw("name", "COALESCE(?, name)", "x").  // with bound args
+    Where("id", "=", 1).
+    Get()
+// UPDATE posts SET views = views + 1, name = COALESCE(?, name) WHERE id = ?
+
 melody.NewDelete("users").
     Where("id", "=", 1).
     Get()
@@ -136,6 +159,16 @@ melody.NewInsert("users").Dialect(melody.Postgres).
 //   ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name
 
 // default dialect: ... ON DUPLICATE KEY UPDATE name = ?
+```
+
+Skip conflicting rows instead of updating:
+
+```go
+melody.NewInsert("users").Dialect(melody.Postgres).
+    Set("id", 1).Set("name", "bob").
+    OnConflict("id").OnConflictDoNothing().
+    Get()
+// INSERT INTO users (id, name) VALUES( $1, $2 ) ON CONFLICT (id) DO NOTHING
 ```
 
 ## HTTP query params → WHERE

--- a/builder.go
+++ b/builder.go
@@ -39,6 +39,7 @@ type where struct {
 	Values   []any
 	IsOn     bool
 	IsOr     bool
+	Raw      string // when set, emitted verbatim; Values are its bound args
 }
 
 type orderBy struct {
@@ -91,6 +92,12 @@ func (b *Builder) OrderBy(field, direction string) *Builder {
 		Key:       field,
 		Direction: direction,
 	})
+	return b
+}
+
+// OrderByRaw appends a raw ORDER BY expression, e.g. OrderByRaw("RANDOM()").
+func (b *Builder) OrderByRaw(expr string) *Builder {
+	b.ctx.OrderBy = append(b.ctx.OrderBy, orderBy{Key: expr})
 	return b
 }
 
@@ -154,23 +161,24 @@ func buildWhere(wc WhereContext, isFirst, isJoin, isSub bool) (result []string, 
 			}
 		}
 
-		if len(w.Values) != 1 && w.Operator != "IN" {
-			return result, params, fmt.Errorf("%s cannot contains multiple value if operator isn't IN", w.Key)
-		}
-
-		if w.IsOn {
+		switch {
+		case w.Raw != "":
+			result = append(result, w.Raw)
+			params = append(params, w.Values...)
+		case w.IsOn:
 			result = append(result, fmt.Sprintf("%s %s %s", w.Key, w.Operator, w.Values[0].(string)))
-		} else {
-			if w.Operator == "IN" {
-				result = append(result, fmt.Sprintf(
-					"%s IN (%s)",
-					w.Key,
-					placeholders(len(w.Values), ","),
-				))
-			} else {
-				result = append(result, fmt.Sprintf("%s %s ?", w.Key, w.Operator))
+		case w.Operator == "IN":
+			result = append(result, fmt.Sprintf(
+				"%s IN (%s)",
+				w.Key,
+				placeholders(len(w.Values), ","),
+			))
+			params = append(params, w.Values...)
+		default:
+			if len(w.Values) != 1 {
+				return result, params, fmt.Errorf("%s cannot contains multiple value if operator isn't IN", w.Key)
 			}
-
+			result = append(result, fmt.Sprintf("%s %s ?", w.Key, w.Operator))
 			params = append(params, w.Values...)
 		}
 	}
@@ -286,7 +294,11 @@ func (b *Builder) build(withOrderBy bool) (res string, params []any, err error) 
 
 		var ol []string
 		for _, o := range b.ctx.OrderBy {
-			ol = append(ol, fmt.Sprintf("%s %s", o.Key, o.Direction))
+			if o.Direction == "" {
+				ol = append(ol, o.Key) // raw expression, e.g. RANDOM()
+			} else {
+				ol = append(ol, fmt.Sprintf("%s %s", o.Key, o.Direction))
+			}
 		}
 
 		result = append(result, strings.Join(ol, ", "))

--- a/delete.go
+++ b/delete.go
@@ -45,6 +45,34 @@ func (d *DeleteBuilder) OrWhere(key string, operator string, values ...any) *Del
 	return d.where(key, operator, values, true, false)
 }
 
+func (d *DeleteBuilder) WhereRaw(expr string, args ...any) *DeleteBuilder {
+	return d.raw(expr, false, args)
+}
+
+func (d *DeleteBuilder) OrWhereRaw(expr string, args ...any) *DeleteBuilder {
+	return d.raw(expr, true, args)
+}
+
+func (d *DeleteBuilder) WhereNull(key string) *DeleteBuilder {
+	return d.raw(key+" IS NULL", false, nil)
+}
+func (d *DeleteBuilder) OrWhereNull(key string) *DeleteBuilder {
+	return d.raw(key+" IS NULL", true, nil)
+}
+func (d *DeleteBuilder) WhereNotNull(key string) *DeleteBuilder {
+	return d.raw(key+" IS NOT NULL", false, nil)
+}
+func (d *DeleteBuilder) OrWhereNotNull(key string) *DeleteBuilder {
+	return d.raw(key+" IS NOT NULL", true, nil)
+}
+
+func (d *DeleteBuilder) raw(expr string, isOr bool, args []any) *DeleteBuilder {
+	d.ctx.Where = append(d.ctx.Where, WhereContext{
+		Values: []where{{Raw: expr, Values: args, IsOr: isOr}},
+	})
+	return d
+}
+
 func (d *DeleteBuilder) GroupWhere(sub SubBuilderFunc) *DeleteBuilder {
 	return d.sub(sub, false)
 }

--- a/dialect.go
+++ b/dialect.go
@@ -35,6 +35,13 @@ var Postgres Dialect = postgresDialect{}
 // ON CONFLICT ... DO UPDATE SET upsert (not MySQL's ON DUPLICATE KEY).
 var SQLite Dialect = sqliteDialect{}
 
+// doNothingDialect is an optional capability: a dialect that can render an
+// "insert, skip on conflict" clause. Detected via type assertion so the public
+// Dialect interface stays unchanged (custom dialects need not implement it).
+type doNothingDialect interface {
+	ConflictDoNothing(conflict, columns []string) string
+}
+
 type defaultDialect struct{}
 
 func (defaultDialect) Rebind(query string) string { return query }
@@ -45,6 +52,15 @@ func (defaultDialect) UpsertClause(_, update []string) (string, bool) {
 		sets[i] = c + " = ?"
 	}
 	return "ON DUPLICATE KEY UPDATE " + strings.Join(sets, ", "), true
+}
+
+// ConflictDoNothing: MySQL has no DO NOTHING, so emit a no-op self-assignment.
+func (defaultDialect) ConflictDoNothing(_, columns []string) string {
+	if len(columns) == 0 {
+		return "ON DUPLICATE KEY UPDATE"
+	}
+	c := columns[0]
+	return "ON DUPLICATE KEY UPDATE " + c + " = " + c
 }
 
 type postgresDialect struct{}
@@ -69,12 +85,28 @@ func (postgresDialect) UpsertClause(conflict, update []string) (string, bool) {
 	return onConflictClause(conflict, update)
 }
 
+func (postgresDialect) ConflictDoNothing(conflict, _ []string) string {
+	return doNothingClause(conflict)
+}
+
 type sqliteDialect struct{}
 
 func (sqliteDialect) Rebind(query string) string { return query }
 
 func (sqliteDialect) UpsertClause(conflict, update []string) (string, bool) {
 	return onConflictClause(conflict, update)
+}
+
+func (sqliteDialect) ConflictDoNothing(conflict, _ []string) string {
+	return doNothingClause(conflict)
+}
+
+func doNothingClause(conflict []string) string {
+	target := ""
+	if len(conflict) > 0 {
+		target = " (" + strings.Join(conflict, ", ") + ")"
+	}
+	return "ON CONFLICT" + target + " DO NOTHING"
 }
 
 // onConflictClause renders the Postgres/SQLite upsert clause. It needs no extra

--- a/group_where.go
+++ b/group_where.go
@@ -26,6 +26,28 @@ func (b *WhereContext) OrWhere(key string, operator string, values ...any) *Wher
 	return b.where(key, operator, values, true, false)
 }
 
+func (b *WhereContext) WhereRaw(expr string, args ...any) *WhereContext {
+	return b.raw(expr, false, args)
+}
+
+func (b *WhereContext) OrWhereRaw(expr string, args ...any) *WhereContext {
+	return b.raw(expr, true, args)
+}
+
+func (b *WhereContext) WhereNull(key string) *WhereContext   { return b.raw(key+" IS NULL", false, nil) }
+func (b *WhereContext) OrWhereNull(key string) *WhereContext { return b.raw(key+" IS NULL", true, nil) }
+func (b *WhereContext) WhereNotNull(key string) *WhereContext {
+	return b.raw(key+" IS NOT NULL", false, nil)
+}
+func (b *WhereContext) OrWhereNotNull(key string) *WhereContext {
+	return b.raw(key+" IS NOT NULL", true, nil)
+}
+
+func (b *WhereContext) raw(expr string, isOr bool, args []any) *WhereContext {
+	b.Values = append(b.Values, where{Raw: expr, Values: args, IsOr: isOr})
+	return b
+}
+
 func (b *WhereContext) On(firstKey string, operator string, secondKey string) *WhereContext {
 	return b.where(firstKey, operator, []any{secondKey}, false, true)
 }

--- a/insert.go
+++ b/insert.go
@@ -17,6 +17,7 @@ type insertContext struct {
 	Rows           [][]any
 	DupKeys        []string // columns to overwrite on conflict
 	ConflictTarget []string // unique columns the conflict is detected on (Postgres)
+	DoNothing      bool     // emit ON CONFLICT DO NOTHING instead of an update
 	Returning      []string
 }
 
@@ -80,6 +81,14 @@ func (i *InsertBuilder) OnConflict(columns ...string) *InsertBuilder {
 	return i
 }
 
+// OnConflictDoNothing skips rows that violate a unique constraint
+// (Postgres/SQLite: ON CONFLICT DO NOTHING; default/MySQL: a no-op
+// ON DUPLICATE KEY UPDATE). Pair with OnConflict to target specific columns.
+func (i *InsertBuilder) OnConflictDoNothing() *InsertBuilder {
+	i.ctx.DoNothing = true
+	return i
+}
+
 func (i *InsertBuilder) dia() Dialect {
 	if i.dialect == nil {
 		return Default
@@ -127,7 +136,13 @@ func (i *InsertBuilder) build() (res string, params []any, err error) {
 		result = append(result, "VALUES "+strings.Join(rows, ", "))
 	}
 
-	if len(i.ctx.DupKeys) > 0 {
+	if i.ctx.DoNothing {
+		d, ok := i.dia().(doNothingDialect)
+		if !ok {
+			return res, params, errors.New("dialect does not support ON CONFLICT DO NOTHING")
+		}
+		result = append(result, d.ConflictDoNothing(i.ctx.ConflictTarget, i.ctx.Columns))
+	} else if len(i.ctx.DupKeys) > 0 {
 		clause, withParams := i.dia().UpsertClause(i.ctx.ConflictTarget, i.ctx.DupKeys)
 		result = append(result, clause)
 		if withParams {

--- a/raw_test.go
+++ b/raw_test.go
@@ -1,0 +1,82 @@
+package melody
+
+import "testing"
+
+func TestWhereNull(t *testing.T) {
+	q, p, err := New("users").Where("active", "=", true).WhereNull("deleted_at").Get()
+	eq(t, "is null", q, p, err,
+		"SELECT * FROM users WHERE active = ? AND deleted_at IS NULL", []any{true})
+}
+
+func TestWhereNotNullOr(t *testing.T) {
+	q, p, err := New("users").Where("id", "=", 1).OrWhereNotNull("email").Get()
+	eq(t, "is not null or", q, p, err,
+		"SELECT * FROM users WHERE id = ? OR email IS NOT NULL", []any{1})
+}
+
+func TestWhereRaw(t *testing.T) {
+	q, p, err := New("users").WhereRaw("LOWER(name) LIKE LOWER(?)", "%bob%").Get()
+	eq(t, "raw like", q, p, err,
+		"SELECT * FROM users WHERE LOWER(name) LIKE LOWER(?)", []any{"%bob%"})
+}
+
+func TestWhereRawExistsAndBind(t *testing.T) {
+	q, p, err := New("users").
+		Where("active", "=", true).
+		WhereRaw("EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id AND total > ?)", 100).
+		Get()
+	eq(t, "raw exists", q, p, err,
+		"SELECT * FROM users WHERE active = ? AND EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id AND total > ?)",
+		[]any{true, 100})
+}
+
+func TestRawInsideGroup(t *testing.T) {
+	q, p, err := New("users").
+		Where("active", "=", true).
+		GroupWhere(func(w *WhereContext) {
+			w.WhereNull("a").OrWhereRaw("b > ?", 5)
+		}).Get()
+	eq(t, "raw in group", q, p, err,
+		"SELECT * FROM users WHERE active = ? AND ( a IS NULL OR b > ? )", []any{true, 5})
+}
+
+func TestOrderByRaw(t *testing.T) {
+	q, _, err := New("users").OrderByRaw("RANDOM()").Get()
+	if err != nil || q != "SELECT * FROM users ORDER BY RANDOM()" {
+		t.Errorf("order by raw: %q (err=%v)", q, err)
+	}
+}
+
+func TestUpdateSetRaw(t *testing.T) {
+	q, p, err := NewUpdate("posts").
+		SetRaw("views", "views + 1").
+		Set("title", "hi").
+		SetRaw("name", "COALESCE(?, name)", "new").
+		Where("id", "=", 1).Get()
+	eq(t, "set raw", q, p, err,
+		"UPDATE posts SET views = views + 1, title = ?, name = COALESCE(?, name) WHERE id = ?",
+		[]any{"hi", "new", 1})
+}
+
+func TestPostgresDoNothing(t *testing.T) {
+	q, p, err := NewInsert("users").Dialect(Postgres).
+		Set("id", 1).Set("name", "bob").
+		OnConflict("id").OnConflictDoNothing().Get()
+	eq(t, "pg do nothing", q, p, err,
+		"INSERT INTO users (id, name) VALUES( $1, $2 ) ON CONFLICT (id) DO NOTHING",
+		[]any{1, "bob"})
+}
+
+func TestSQLiteDoNothingNoTarget(t *testing.T) {
+	q, p, err := NewInsert("users").Dialect(SQLite).
+		Set("name", "bob").OnConflictDoNothing().Get()
+	eq(t, "sqlite do nothing", q, p, err,
+		"INSERT INTO users (name) VALUES( ? ) ON CONFLICT DO NOTHING", []any{"bob"})
+}
+
+func TestDefaultDoNothingMySQL(t *testing.T) {
+	q, p, err := NewInsert("users").
+		Set("id", 1).Set("name", "bob").OnConflictDoNothing().Get()
+	eq(t, "mysql do nothing", q, p, err,
+		"INSERT INTO users (id, name) VALUES( ?, ? ) ON DUPLICATE KEY UPDATE id = id", []any{1, "bob"})
+}

--- a/select_where.go
+++ b/select_where.go
@@ -26,6 +26,31 @@ func (b *Builder) OrWhere(key string, operator string, values ...any) *Builder {
 	return b.where(key, operator, values, true, false)
 }
 
+// WhereRaw adds a raw boolean predicate, e.g.
+// WhereRaw("LOWER(name) LIKE LOWER(?)", "%bob%") or
+// WhereRaw("EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id)").
+func (b *Builder) WhereRaw(expr string, args ...any) *Builder {
+	return b.raw(expr, false, args)
+}
+
+func (b *Builder) OrWhereRaw(expr string, args ...any) *Builder {
+	return b.raw(expr, true, args)
+}
+
+func (b *Builder) WhereNull(key string) *Builder    { return b.raw(key+" IS NULL", false, nil) }
+func (b *Builder) OrWhereNull(key string) *Builder  { return b.raw(key+" IS NULL", true, nil) }
+func (b *Builder) WhereNotNull(key string) *Builder { return b.raw(key+" IS NOT NULL", false, nil) }
+func (b *Builder) OrWhereNotNull(key string) *Builder {
+	return b.raw(key+" IS NOT NULL", true, nil)
+}
+
+func (b *Builder) raw(expr string, isOr bool, args []any) *Builder {
+	b.ctx.Where = append(b.ctx.Where, WhereContext{
+		Values: []where{{Raw: expr, Values: args, IsOr: isOr}},
+	})
+	return b
+}
+
 func (b *Builder) On(firstKey string, operator string, secondKey string) *Builder {
 	return b.where(firstKey, operator, []any{secondKey}, false, true)
 }

--- a/update.go
+++ b/update.go
@@ -21,6 +21,8 @@ type updateContext struct {
 type updateValue struct {
 	Column string
 	Value  any
+	Raw    string // when set, RHS is this expression; Args are its bound params
+	Args   []any
 }
 
 func NewUpdate(table string) *UpdateBuilder {
@@ -39,6 +41,13 @@ func (u *UpdateBuilder) Dialect(d Dialect) *UpdateBuilder {
 
 func (u *UpdateBuilder) Set(column string, value any) *UpdateBuilder {
 	u.ctx.Value = append(u.ctx.Value, updateValue{Column: column, Value: value})
+	return u
+}
+
+// SetRaw sets a column to a raw expression instead of a bound value, e.g.
+// SetRaw("views", "views + 1") or SetRaw("name", "COALESCE(?, name)", newName).
+func (u *UpdateBuilder) SetRaw(column, expr string, args ...any) *UpdateBuilder {
+	u.ctx.Value = append(u.ctx.Value, updateValue{Column: column, Raw: expr, Args: args})
 	return u
 }
 
@@ -67,8 +76,13 @@ func (u *UpdateBuilder) build() (res string, params []any, err error) {
 
 	var resultValue []string
 	for _, v := range u.ctx.Value {
-		resultValue = append(resultValue, fmt.Sprintf("%s = ?", v.Column))
-		params = append(params, v.Value)
+		if v.Raw != "" {
+			resultValue = append(resultValue, fmt.Sprintf("%s = %s", v.Column, v.Raw))
+			params = append(params, v.Args...)
+		} else {
+			resultValue = append(resultValue, fmt.Sprintf("%s = ?", v.Column))
+			params = append(params, v.Value)
+		}
 	}
 
 	result = append(result, strings.Join(resultValue, ", "))

--- a/update_where.go
+++ b/update_where.go
@@ -26,6 +26,34 @@ func (u *UpdateBuilder) OrWhere(key string, operator string, values ...any) *Upd
 	return u.where(key, operator, values, true, false)
 }
 
+func (u *UpdateBuilder) WhereRaw(expr string, args ...any) *UpdateBuilder {
+	return u.raw(expr, false, args)
+}
+
+func (u *UpdateBuilder) OrWhereRaw(expr string, args ...any) *UpdateBuilder {
+	return u.raw(expr, true, args)
+}
+
+func (u *UpdateBuilder) WhereNull(key string) *UpdateBuilder {
+	return u.raw(key+" IS NULL", false, nil)
+}
+func (u *UpdateBuilder) OrWhereNull(key string) *UpdateBuilder {
+	return u.raw(key+" IS NULL", true, nil)
+}
+func (u *UpdateBuilder) WhereNotNull(key string) *UpdateBuilder {
+	return u.raw(key+" IS NOT NULL", false, nil)
+}
+func (u *UpdateBuilder) OrWhereNotNull(key string) *UpdateBuilder {
+	return u.raw(key+" IS NOT NULL", true, nil)
+}
+
+func (u *UpdateBuilder) raw(expr string, isOr bool, args []any) *UpdateBuilder {
+	u.ctx.Where = append(u.ctx.Where, WhereContext{
+		Values: []where{{Raw: expr, Values: args, IsOr: isOr}},
+	})
+	return u
+}
+
 func (u *UpdateBuilder) On(firstKey string, operator string, secondKey string) *UpdateBuilder {
 	return u.where(firstKey, operator, []any{secondKey}, false, true)
 }


### PR DESCRIPTION
Fills the real gaps from the audit table. Several rows there already existed in melody (JOIN, GROUP BY, runtime IN, GetCount) or don't apply (transactions / pool helpers — melody is a pure builder), so this PR covers what was genuinely missing.

| Added | Covers |
|---|---|
| `WhereNull` / `WhereNotNull` (+ `Or*`) | `IS NULL` / `IS NOT NULL` |
| `WhereRaw` / `OrWhereRaw` | `LOWER(col) LIKE LOWER(?)`, `EXISTS`/`NOT EXISTS`, custom `IN`, any predicate |
| `SetRaw` (Update) | `col = col + 1`, `COALESCE`/`NULLIF`/`CASE` |
| `OrderByRaw` | `ORDER BY RANDOM()` |
| `OnConflictDoNothing` | `ON CONFLICT … DO NOTHING` (pg/sqlite), no-op `ON DUPLICATE KEY` (mysql) |

Implementation:
- A `Raw` field on the internal `where` and `updateValue` drives all of it; `buildWhere` emits it verbatim and binds its args.
- Predicate methods added to all four where-holders (Builder, WhereContext, UpdateBuilder, DeleteBuilder).
- `ON CONFLICT DO NOTHING` is rendered through an **optional** dialect capability detected by type assertion (`doNothingDialect`), so the public `Dialect` interface is **unchanged** (no break for external implementers).

10 new tests; 53 total, `go vet` clean. Existing characterization tests still green (buildWhere refactor is behaviour-preserving).