### PR TITLE
fix: support NOT IN with multiple values

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -167,16 +167,17 @@ func buildWhere(wc WhereContext, isFirst, isJoin, isSub bool) (result []string, 
 			params = append(params, w.Values...)
 		case w.IsOn:
 			result = append(result, fmt.Sprintf("%s %s %s", w.Key, w.Operator, w.Values[0].(string)))
-		case w.Operator == "IN":
+		case w.Operator == "IN" || w.Operator == "NOT IN":
 			result = append(result, fmt.Sprintf(
-				"%s IN (%s)",
+				"%s %s (%s)",
 				w.Key,
+				w.Operator,
 				placeholders(len(w.Values), ","),
 			))
 			params = append(params, w.Values...)
 		default:
 			if len(w.Values) != 1 {
-				return result, params, fmt.Errorf("%s cannot contains multiple value if operator isn't IN", w.Key)
+				return result, params, fmt.Errorf("%s cannot contain multiple values unless operator is IN or NOT IN", w.Key)
 			}
 			result = append(result, fmt.Sprintf("%s %s ?", w.Key, w.Operator))
 			params = append(params, w.Values...)

--- a/raw_test.go
+++ b/raw_test.go
@@ -80,3 +80,16 @@ func TestDefaultDoNothingMySQL(t *testing.T) {
 	eq(t, "mysql do nothing", q, p, err,
 		"INSERT INTO users (id, name) VALUES( ?, ? ) ON DUPLICATE KEY UPDATE id = id", []any{1, "bob"})
 }
+
+func TestWhereNotIn(t *testing.T) {
+	q, p, err := New("users").Where("status", "NOT IN", "banned", "deleted").Get()
+	eq(t, "not in", q, p, err,
+		"SELECT * FROM users WHERE status NOT IN (?,?)", []any{"banned", "deleted"})
+}
+
+func TestWhereNotInPostgres(t *testing.T) {
+	q, p, err := New("users").Dialect(Postgres).
+		Where("id", "NOT IN", 1, 2, 3).Get()
+	eq(t, "not in pg", q, p, err,
+		"SELECT * FROM users WHERE id NOT IN ($1,$2,$3)", []any{1, 2, 3})
+}


### PR DESCRIPTION
`buildWhere` only special-cased `IN`, so `Where(col, "NOT IN", vals...)` returned *cannot contain multiple values*. The `WithQueryParams` `[not-in]` filter (which already emits `NOT IN`) was broken by the same cause.

```go
melody.New("users").Where("status", "NOT IN", "banned", "deleted").Get()
// SELECT * FROM users WHERE status NOT IN (?,?)
```

2 tests added (default + Postgres). 55 total, vet clean.